### PR TITLE
Allow direct disposal of entities

### DIFF
--- a/Core/EntityExtensions.cs
+++ b/Core/EntityExtensions.cs
@@ -200,7 +200,7 @@ namespace Morpeh {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void Dispose(this Entity entity) {
+        public static void Dispose(this Entity entity) {
             if (entity.isDisposed) {
 #if MORPEH_DEBUG
                 MDebug.LogError($"You're trying to dispose disposed entity with ID {entity.ID}.");


### PR DESCRIPTION
World does not have any logic around disposal of entities, so we can allow direct calls of Dispose on entities without referencing its world anywhere.