### PR TITLE
Allow overriding Morpeh logger with custom implementations

### DIFF
--- a/Core/Logging/IMorpehLogger.cs
+++ b/Core/Logging/IMorpehLogger.cs
@@ -1,0 +1,10 @@
+﻿namespace Morpeh.Logging
+{
+    public interface IMorpehLogger
+    {
+        public void Log(string message) { }
+        public void LogWarning(string message) { }
+        public void LogError(string message) { }
+        public void LogException(System.Exception exception) { }
+    }
+}

--- a/Core/Logging/MorpehSystemLogger.cs
+++ b/Core/Logging/MorpehSystemLogger.cs
@@ -1,0 +1,10 @@
+﻿namespace Morpeh.Logging
+{
+    internal class MorpehSystemLogger : IMorpehLogger
+    {
+        public void Log(string message) => System.Console.WriteLine(message);
+        public void LogWarning(string message) => System.Console.WriteLine(message);
+        public void LogError(string message) => System.Console.WriteLine(message);
+        public void LogException(System.Exception exception) => System.Console.WriteLine(exception);
+    }
+}

--- a/Core/Logging/MorpehUnityLogger.cs
+++ b/Core/Logging/MorpehUnityLogger.cs
@@ -1,0 +1,12 @@
+﻿#if UNITY_2019_1_OR_NEWER
+namespace Morpeh.Logging
+{
+    internal class MorpehUnityLogger : IMorpehLogger
+    {
+        public void Log(string message) => UnityEngine.Debug.Log(message);
+        public void LogWarning(string message) => UnityEngine.Debug.LogWarning(message);
+        public void LogError(string message) => UnityEngine.Debug.LogError(message);
+        public void LogException(System.Exception exception) => UnityEngine.Debug.LogException(exception);
+    }
+}
+#endif

--- a/Core/MDebug.cs
+++ b/Core/MDebug.cs
@@ -1,3 +1,4 @@
+using Morpeh.Logging;
 #if UNITY_EDITOR
 #define MORPEH_DEBUG
 #endif
@@ -9,19 +10,18 @@ namespace Morpeh {
     using System;
     using System.Diagnostics;
     
-    internal static class MDebug {
+    internal static class MDebug
+    {
         [Conditional("MORPEH_DEBUG")]
-        public static void Log(object message) => UnityEngine.Debug.Log($"[MORPEH] {message}");
+        public static void Log(object message) => MorpehSettings.Logger.Log($"[MORPEH] {message}");
         
         [Conditional("MORPEH_DEBUG")]
-        public static void LogWarning(object message) => UnityEngine.Debug.LogWarning($"[MORPEH] {message}");
+        public static void LogWarning(object message) => MorpehSettings.Logger.LogWarning($"[MORPEH] {message}");
         
         [Conditional("MORPEH_DEBUG")]
-        public static void LogError(object message) => UnityEngine.Debug.LogError($"[MORPEH] {message}");
+        public static void LogError(object message) => MorpehSettings.Logger.LogError($"[MORPEH] {message}");
         
         [Conditional("MORPEH_DEBUG")]
-        public static void LogException(Exception e) => UnityEngine.Debug.LogException(e);
-        
-
+        public static void LogException(Exception e) => MorpehSettings.Logger.LogException(e);
     }
 }

--- a/Core/MDebug.cs
+++ b/Core/MDebug.cs
@@ -10,8 +10,7 @@ namespace Morpeh {
     using System;
     using System.Diagnostics;
     
-    internal static class MDebug
-    {
+    internal static class MDebug {
         [Conditional("MORPEH_DEBUG")]
         public static void Log(object message) => MorpehSettings.Logger.Log($"[MORPEH] {message}");
         

--- a/Core/Morpeh.cs
+++ b/Core/Morpeh.cs
@@ -69,6 +69,7 @@ namespace Unity.IL2CPP.CompilerServices {
 #if !UNITY_2019_1_OR_NEWER
 namespace UnityEngine {
     public sealed class SerializeField : System.Attribute { }
+    public sealed class GameObject : System.Object { }
 }
 
 namespace UnityEngine.Scripting {

--- a/Core/MorpehSettings.cs
+++ b/Core/MorpehSettings.cs
@@ -1,0 +1,17 @@
+﻿namespace Morpeh
+{
+    using Logging;
+    
+    public static class MorpehSettings
+    {
+#if UNITY_2019_1_OR_NEWER
+        internal static IMorpehLogger Logger = new MorpehUnityLogger();
+#else
+        internal static IMorpehLogger Logger = new MorpehSystemLogger();
+#endif
+        
+        public static void UseLogger(IMorpehLogger logger) {
+            Logger = logger;
+        }
+    }
+}

--- a/Core/MorpehSettings.cs
+++ b/Core/MorpehSettings.cs
@@ -2,8 +2,7 @@
 {
     using Logging;
     
-    public static class MorpehSettings
-    {
+    public static class MorpehSettings {
 #if UNITY_2019_1_OR_NEWER
         internal static IMorpehLogger Logger = new MorpehUnityLogger();
 #else


### PR DESCRIPTION
Currently, logging is bound to Unity without an option to use custom loggers like Serilog.
This rework allows implementing IMorpehLogger interface for custom logging classes with methods like Log, LogWarning, LogError, LogException.

API:
`IMorpehLogger` - interface to implement in custom logger
`MorpehSettings.UseLogger(IMorpehLogger logger)` - switch logger to another object