### PR TITLE
Fix entity detected as alive when it's not

### DIFF
--- a/Core/EntityExtensions.cs
+++ b/Core/EntityExtensions.cs
@@ -249,6 +249,6 @@ namespace Morpeh {
         public static bool IsDisposed([NotNull] this Entity entity) => entity.isDisposed;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsNullOrDisposed([CanBeNull] this Entity entity) => entity == null || entity.isDisposed;
+        public static bool IsNullOrDisposed([CanBeNull] this Entity entity) => entity == null || entity.isDisposed || entity.world == null;
     }
 }


### PR DESCRIPTION
In certain situations like:
* Storing entity inside a ScriptableObject without making an instance of that ScriptableObject in runtime
* Storing entity as public field of MonoBehaviour but without having a goal of it being serialized
* Other
an entity can have entity.IsNullOrDisposed() equal false, even though entity.world is already null and missing. This may cause a lot of confusion, leading to hard-to-catch bugs and exceptions.

This PR aims to treat all entities as disposed when the world reference is missing for any reason.