### PR TITLE
Allow core of morpeh to be non-serialized with a define

### DIFF
--- a/Core/Archetype.cs
+++ b/Core/Archetype.cs
@@ -4,7 +4,9 @@ namespace Morpeh {
     using Unity.IL2CPP.CompilerServices;
     using UnityEngine;
     
+#if !MORPEH_NON_SERIALIZED
     [Serializable]
+#endif
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]

--- a/Core/ComponentsCache.cs
+++ b/Core/ComponentsCache.cs
@@ -11,8 +11,10 @@ namespace Morpeh {
     using Collections;
     using Unity.IL2CPP.CompilerServices;
     using UnityEngine;
-
+    
+#if !MORPEH_NON_SERIALIZED
     [Serializable]
+#endif
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
@@ -42,8 +44,10 @@ namespace Morpeh {
 
         public abstract void Dispose();
     }
-
+    
+#if !MORPEH_NON_SERIALIZED
     [Serializable]
+#endif
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
@@ -242,8 +246,10 @@ namespace Morpeh {
             caches.RemoveSwap(this, out _);
         }
     }
-
+    
+#if !MORPEH_NON_SERIALIZED
     [Serializable]
+#endif
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]

--- a/Core/Entity.cs
+++ b/Core/Entity.cs
@@ -4,7 +4,9 @@ namespace Morpeh {
     using Unity.IL2CPP.CompilerServices;
     using UnityEngine;
     
+#if !MORPEH_NON_SERIALIZED
     [Serializable]
+#endif
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]

--- a/Core/World.cs
+++ b/Core/World.cs
@@ -15,7 +15,9 @@ namespace Morpeh {
     using Unity.IL2CPP.CompilerServices;
     using UnityEngine;
     
+#if !MORPEH_NON_SERIALIZED
     [Serializable]
+#endif
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]


### PR DESCRIPTION
Added a new define: MORPEH_NON_SERIALIZED
Which disables [Serializable] attribute on classes:
* Archetype
* ComponentsCache (and its inherited versions)
* Entity
* World
For projects where serialization of world/entities is not required