### PR TITLE
🚧 Fix Migration and Up Version to Unity 2022.1.2

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2022.1.2] - 14.11.2022
+### Fixed
+- Fix MigrateTo() method. Entity archetypes were not changed when the method was called.
+
 ## [2022.1.1] - 31.10.2022
 ### Added
 - Add .meta file for CHANGELOG.MD

--- a/Core/ComponentsCache.cs
+++ b/Core/ComponentsCache.cs
@@ -230,15 +230,22 @@ namespace Morpeh {
                         this.components.Set(to.entityId.id, component, out _);
                     }
                     else {
-                        this.components.Add(to.entityId.id, component, out _);
+                        if (this.components.Add(to.entityId.id, component, out _)) {
+                            to.AddTransfer(this.typeId);
+                        }
                     }
                 }
                 else {
                     if (this.components.Has(to.entityId.id) == false) {
-                        this.components.Add(to.entityId.id, component, out _);
+                        if (this.components.Add(to.entityId.id, component, out _)) {
+                            to.AddTransfer(this.typeId);
+                        }
                     }
                 }
-                this.components.Remove(from.entityId.id, out _);
+
+                if (this.components.Remove(from.entityId.id, out _)) {
+                    from.RemoveTransfer(this.typeId);
+                }
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Currently require [Odin Inspector](https://assetstore.unity.com/packages/tools/u
 
 &nbsp;&nbsp;&nbsp;&nbsp;⭐ Master: https://github.com/scellecs/morpeh.git  
 &nbsp;&nbsp;&nbsp;&nbsp;🚧 Dev:  https://github.com/scellecs/morpeh.git#develop  
-&nbsp;&nbsp;&nbsp;&nbsp;🏷️ Tag:  https://github.com/scellecs/morpeh.git#2022.1.1
+&nbsp;&nbsp;&nbsp;&nbsp;🏷️ Tag:  https://github.com/scellecs/morpeh.git#2022.1.2  
 
 <details>
     <summary>You can update Morpeh by Discover Window. Select Help/Morpeh Discover menu.   </summary>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Morpeh",
   "description": "Fast and Simple ECS Framework for Unity Game Engine.",
   "unity": "2019.4",
-  "version": "2022.1.1",
+  "version": "2022.1.2",
   "keywords": [
     "morpeh",
     "ecs"


### PR DESCRIPTION
Fix MigrateTo() method. Entity archetypes were not changed when the method was called.
Done by @vanifatovvlad.

https://github.com/scellecs/morpeh/pull/148