### PR TITLE
Added RemoveAll() for Stash

### DIFF
--- a/Core/Stash.cs
+++ b/Core/Stash.cs
@@ -39,6 +39,9 @@ namespace Scellecs.Morpeh {
         public abstract bool Remove(Entity entity);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public abstract void RemoveAll();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal abstract bool Clean(Entity entity);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -238,6 +241,27 @@ namespace Scellecs.Morpeh {
                 return true;
             }
             return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override void RemoveAll() {
+            world.ThreadSafetyCheck();
+
+            if (this.componentDispose != null) {
+                foreach (var index in this.components) {
+                    this.componentDispose.Invoke(ref this.components.data[index]);
+
+                    var entityId = this.components.GetKeyByIndex(index);
+                    this.world.GetEntity(entityId).RemoveTransfer(this.typeId);
+                }
+            } else {
+                foreach (var index in this.components) {
+                    var entityId = this.components.GetKeyByIndex(index);
+                    this.world.GetEntity(entityId).RemoveTransfer(this.typeId);
+                }
+            }
+
+            this.components.Clear();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Added RemoveAll() method for Stash.
It works 20% faster in average than classic `foreach(Entity ent in filter) stash.Remove(ent);` in Mono and up to 30% faster in IL2CPP.

Measurements for 1.000.000 entities in Mono.
Tests for common(`Common`) and IDisposable(`Dispose`) component types. Time includes `World.Commit()`.
![image](https://user-images.githubusercontent.com/17111024/212557508-053f0b2f-336c-4cdf-bbdb-db1e48a257d1.png)

Measurements for 1.000.000 entities in IL2CPP: 
```
Filter avg: Common=156ms Dispose=166ms
Stash avg: Common=108ms Dispose=116ms
Improvement: Common=30,77% Dispose=30,12%
```
[Player.log](https://github.com/scellecs/morpeh/files/10423950/Player.log)