### PR TITLE
Delete Enumerator from all collections & Filter

### DIFF
--- a/Core/Collections/BitMap.cs
+++ b/Core/Collections/BitMap.cs
@@ -9,7 +9,7 @@ namespace Scellecs.Morpeh.Collections {
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public sealed class BitMap : IEnumerable<int> {
+    public sealed class BitMap {
         internal const int BITS_PER_BYTE        = 8;
         internal const int BITS_PER_FIELD       = BITS_PER_BYTE * sizeof(int);
         internal const int BITS_PER_FIELD_SHIFT = 5; //5 for int, 6 for long
@@ -46,10 +46,6 @@ namespace Scellecs.Morpeh.Collections {
             this.slots.Dispose();
         }
 
-        IEnumerator<int> IEnumerable<int>.GetEnumerator() => this.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Enumerator GetEnumerator() {
             Enumerator e;
@@ -64,7 +60,7 @@ namespace Scellecs.Morpeh.Collections {
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-        public unsafe struct Enumerator : IEnumerator<int> {
+        public unsafe struct Enumerator {
             public BitMap bitMap;
 
             public int index;
@@ -105,18 +101,6 @@ namespace Scellecs.Morpeh.Collections {
             }
 
             public int Current => this.current;
-
-            object IEnumerator.Current => this.current;
-
-            void IEnumerator.Reset() {
-                this.index            = default;
-                this.current          = default;
-                this.currentData      = default;
-                this.currentDataIndex = default;
-            }
-
-            public void Dispose() {
-            }
         }
     }
 }

--- a/Core/Collections/BitMapExtensions.cs
+++ b/Core/Collections/BitMapExtensions.cs
@@ -247,5 +247,24 @@ namespace Scellecs.Morpeh.Collections {
             }
             return 0;
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int First(this BitMap bitmap) {
+            if (bitmap.length == 0) {
+                return -1;
+            }
+
+            var slotsPtr = bitmap.slots.ptr;
+            var dataPtr = bitmap.data.ptr;
+            for (int i = 0, len = bitmap.lastIndex; i < len; i += 2) {
+                var slotPtr = slotsPtr + i;
+                var data    = *(dataPtr + (i >> 1));
+                if (data != 0) {
+                    return (*slotPtr - 1 << BitMap.BITS_PER_FIELD_SHIFT) + NumberOfTrailingZeros(data);
+                }
+            }
+
+            return -1;
+        }
     }
 }

--- a/Core/Collections/FastList.cs
+++ b/Core/Collections/FastList.cs
@@ -9,7 +9,7 @@ namespace Scellecs.Morpeh.Collections {
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public sealed class FastList<T> : IEnumerable<T> {
+    public sealed class FastList<T> {
         public T[] data;
         public int length;
         public int capacity;
@@ -59,10 +59,6 @@ namespace Scellecs.Morpeh.Collections {
             return e;
         }
 
-        IEnumerator<T> IEnumerable<T>.GetEnumerator() => this.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
@@ -74,7 +70,7 @@ namespace Scellecs.Morpeh.Collections {
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-        public struct Enumerator : IEnumerator<T> {
+        public struct Enumerator {
             public FastList<T> list;
 
             public int length;
@@ -110,10 +106,6 @@ namespace Scellecs.Morpeh.Collections {
             }
 
             public T           Current => this.current;
-            object IEnumerator.Current => this.current;
-
-            public void Dispose() {
-            }
         }
     }
 }

--- a/Core/Collections/FastListExtensions.cs
+++ b/Core/Collections/FastListExtensions.cs
@@ -37,6 +37,12 @@ namespace Scellecs.Morpeh.Collections {
             list.data[index] = value;
             return index;
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static FastList<T> AddAndReturnThis<T>(this FastList<T> list, T value) {
+            list.Add(value);
+            return list;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void AddListRange<T>(this FastList<T> list, FastList<T> other) {

--- a/Core/Collections/IntFastList.cs
+++ b/Core/Collections/IntFastList.cs
@@ -16,7 +16,7 @@ namespace Scellecs.Morpeh.Collections {
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public sealed unsafe class IntFastList : IEnumerable<int> {
+    public sealed unsafe class IntFastList {
         public int length;
         public int capacity;
 
@@ -53,10 +53,6 @@ namespace Scellecs.Morpeh.Collections {
             return e;
         }
 
-        IEnumerator<int> IEnumerable<int>.GetEnumerator() => this.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
@@ -68,7 +64,7 @@ namespace Scellecs.Morpeh.Collections {
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-        public struct Enumerator : IEnumerator<int> {
+        public struct Enumerator {
             public IntFastList intFastList;
 
             public int current;
@@ -90,10 +86,6 @@ namespace Scellecs.Morpeh.Collections {
             }
 
             public int         Current => this.current;
-            object IEnumerator.Current => this.current;
-
-            public void Dispose() {
-            }
         }
     }
 }

--- a/Core/Collections/IntFastList.cs
+++ b/Core/Collections/IntFastList.cs
@@ -80,11 +80,6 @@ namespace Scellecs.Morpeh.Collections {
                 return true;
             }
 
-            public void Reset() {
-                this.index   = 0;
-                this.current = default;
-            }
-
             public int         Current => this.current;
         }
     }

--- a/Core/Collections/IntHashMap.cs
+++ b/Core/Collections/IntHashMap.cs
@@ -18,7 +18,7 @@ namespace Scellecs.Morpeh.Collections {
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public sealed class IntHashMap<T> : IEnumerable<int> {
+    public sealed class IntHashMap<T> {
         public int length;
         public int capacity;
         public int capacityMinusOne;
@@ -58,14 +58,10 @@ namespace Scellecs.Morpeh.Collections {
             return e;
         }
 
-        IEnumerator<int> IEnumerable<int>.GetEnumerator() => this.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-        public unsafe struct Enumerator : IEnumerator<int> {
+        public unsafe struct Enumerator {
             public IntHashMap<T> hashMap;
 
             public int index;
@@ -90,16 +86,6 @@ namespace Scellecs.Morpeh.Collections {
             }
 
             public int Current => this.current;
-
-            object IEnumerator.Current => this.current;
-
-            void IEnumerator.Reset() {
-                this.index   = 0;
-                this.current = default;
-            }
-
-            public void Dispose() {
-            }
         }
     }
 }

--- a/Core/Collections/IntHashSet.cs
+++ b/Core/Collections/IntHashSet.cs
@@ -9,7 +9,7 @@ namespace Scellecs.Morpeh.Collections {
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public sealed class IntHashSet : IEnumerable<int> {
+    public sealed class IntHashSet {
         public int length;
         public int capacity;
         public int capacityMinusOne;
@@ -44,14 +44,10 @@ namespace Scellecs.Morpeh.Collections {
             return e;
         }
 
-        IEnumerator<int> IEnumerable<int>.GetEnumerator() => this.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-        public unsafe struct Enumerator : IEnumerator<int> {
+        public unsafe struct Enumerator {
             public IntHashSet set;
 
             public int index;
@@ -79,16 +75,6 @@ namespace Scellecs.Morpeh.Collections {
             }
 
             public int Current => this.current;
-
-            object IEnumerator.Current => this.current;
-
-            void IEnumerator.Reset() {
-                this.index   = 0;
-                this.current = default;
-            }
-
-            public void Dispose() {
-            }
         }
     }
 }

--- a/Core/Collections/LongHashMap.cs
+++ b/Core/Collections/LongHashMap.cs
@@ -18,7 +18,7 @@ namespace Scellecs.Morpeh.Collections {
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public sealed class LongHashMap<T> : IEnumerable<int> {
+    public sealed class LongHashMap<T> {
         public int length;
         public int capacity;
         public int capacityMinusOne;
@@ -58,14 +58,10 @@ namespace Scellecs.Morpeh.Collections {
             return e;
         }
 
-        IEnumerator<int> IEnumerable<int>.GetEnumerator() => this.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-        public unsafe struct Enumerator : IEnumerator<int> {
+        public unsafe struct Enumerator {
             public LongHashMap<T> hashMap;
 
             public int index;
@@ -90,16 +86,6 @@ namespace Scellecs.Morpeh.Collections {
             }
 
             public int Current => this.current;
-
-            object IEnumerator.Current => this.current;
-
-            void IEnumerator.Reset() {
-                this.index   = 0;
-                this.current = default;
-            }
-
-            public void Dispose() {
-            }
         }
     }
 }

--- a/Core/Collections/Raw/UnmanagedArray.cs
+++ b/Core/Collections/Raw/UnmanagedArray.cs
@@ -4,7 +4,7 @@ namespace Scellecs.Morpeh.Collections {
     using System.Collections.Generic;
     using System.Runtime.CompilerServices;
 
-    public unsafe struct UnmanagedArray<T> : IEnumerable<T>, IDisposable where T : unmanaged {
+    public unsafe struct UnmanagedArray<T> : IDisposable where T : unmanaged {
         private UnmanagedStorage<T>* ptr;
         private bool IsUnsafeArrayAllocated => this.ptr != null;
         
@@ -77,11 +77,6 @@ namespace Scellecs.Morpeh.Collections {
             this.ptr = null;
         }
 
-
-        IEnumerator<T> IEnumerable<T>.GetEnumerator() => this.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Enumerator GetEnumerator() {
             if (!this.IsCreated) {
@@ -96,7 +91,7 @@ namespace Scellecs.Morpeh.Collections {
             return e;
         }
 
-        public struct Enumerator : IEnumerator<T> {
+        public struct Enumerator {
             public UnmanagedArray<T> array;
 
             public int current;
@@ -106,11 +101,6 @@ namespace Scellecs.Morpeh.Collections {
             public void Reset()    => this.current = -1;
 
             public T Current => ((T*)this.array.ptr->Ptr.ToPointer())[this.current];
-
-            object IEnumerator.Current => this.Current;
-
-            public void Dispose() {
-            }
         }
     }
 }

--- a/Core/Collections/Raw/UnmanagedArray.cs
+++ b/Core/Collections/Raw/UnmanagedArray.cs
@@ -98,7 +98,6 @@ namespace Scellecs.Morpeh.Collections {
             public int length;
             
             public bool MoveNext() => ++this.current < this.length;
-            public void Reset()    => this.current = -1;
 
             public T Current => ((T*)this.array.ptr->Ptr.ToPointer())[this.current];
         }

--- a/Core/Collections/Raw/UnmanagedList.cs
+++ b/Core/Collections/Raw/UnmanagedList.cs
@@ -4,7 +4,7 @@ namespace Scellecs.Morpeh.Collections {
     using System.Collections.Generic;
     using System.Runtime.CompilerServices;
 
-    public unsafe struct UnmanagedList<T> : IEnumerable<T>, IDisposable where T : unmanaged {
+    public unsafe struct UnmanagedList<T> : IDisposable where T : unmanaged {
         private UnmanagedStorage<T>* ptr;
         private bool                 IsUnsafeArrayAllocated => this.ptr != null;
 
@@ -108,10 +108,6 @@ namespace Scellecs.Morpeh.Collections {
             this.ptr = null;
         }
 
-        IEnumerator<T> IEnumerable<T>.GetEnumerator() => this.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Enumerator GetEnumerator() {
             if (!this.IsCreated) {
@@ -126,7 +122,7 @@ namespace Scellecs.Morpeh.Collections {
             return e;
         }
 
-        public struct Enumerator : IEnumerator<T> {
+        public struct Enumerator {
             public UnmanagedList<T> list;
 
             public int  current;
@@ -136,11 +132,6 @@ namespace Scellecs.Morpeh.Collections {
             public void Reset()    => this.current = -1;
 
             public T Current => ((T*)this.list.ptr->Ptr.ToPointer())[this.current];
-
-            object IEnumerator.Current => this.Current;
-
-            public void Dispose() {
-            }
         }
     }
 }

--- a/Core/Collections/Unsafe/PinnedArray.cs
+++ b/Core/Collections/Unsafe/PinnedArray.cs
@@ -18,7 +18,7 @@ namespace Scellecs.Morpeh.Collections {
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public unsafe struct PinnedArray<T> : IDisposable, IEnumerable<T> where T : unmanaged {
+    public unsafe struct PinnedArray<T> : IDisposable where T : unmanaged {
         public T[] value;
         public T* ptr;
 #if MORPEH_UNITY
@@ -85,16 +85,11 @@ namespace Scellecs.Morpeh.Collections {
             e.index   = 0;
             return e;
         }
-
-        IEnumerator<T> IEnumerable<T>.GetEnumerator() => this.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-        
         
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-        public struct Enumerator : IEnumerator<T> {
+        public struct Enumerator {
             public T* ptr;
 
             public int length;
@@ -118,10 +113,6 @@ namespace Scellecs.Morpeh.Collections {
             }
 
             public T           Current => this.current;
-            object IEnumerator.Current => this.current;
-
-            public void Dispose() {
-            }
         }
     }
 }

--- a/Core/Collections/Unsafe/PinnedArray.cs
+++ b/Core/Collections/Unsafe/PinnedArray.cs
@@ -107,11 +107,6 @@ namespace Scellecs.Morpeh.Collections {
                 return true;
             }
 
-            public void Reset() {
-                this.index   = 0;
-                this.current = default;
-            }
-
             public T           Current => this.current;
         }
     }

--- a/Core/Collections/Unsafe/UnsafeFastList.cs
+++ b/Core/Collections/Unsafe/UnsafeFastList.cs
@@ -9,7 +9,7 @@ namespace Scellecs.Morpeh.Collections {
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public sealed unsafe class UnsafeFastList<T> : IEnumerable<T> where T : unmanaged {
+    public sealed unsafe class UnsafeFastList<T> where T : unmanaged {
         public PinnedArray<T> data;
         public int length;
         public int capacity;
@@ -59,10 +59,6 @@ namespace Scellecs.Morpeh.Collections {
             return e;
         }
 
-        IEnumerator<T> IEnumerable<T>.GetEnumerator() => this.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
@@ -74,7 +70,7 @@ namespace Scellecs.Morpeh.Collections {
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-        public struct Enumerator : IEnumerator<T> {
+        public struct Enumerator {
             public UnsafeFastList<T> list;
 
             public int length;
@@ -110,10 +106,6 @@ namespace Scellecs.Morpeh.Collections {
             }
 
             public T           Current => this.current;
-            object IEnumerator.Current => this.current;
-
-            public void Dispose() {
-            }
         }
     }
 }

--- a/Core/Collections/Unsafe/UnsafeFastList.cs
+++ b/Core/Collections/Unsafe/UnsafeFastList.cs
@@ -99,12 +99,6 @@ namespace Scellecs.Morpeh.Collections {
                 return true;
             }
 
-            public void Reset() {
-                this.index   = 0;
-                this.current = default;
-                this.list.lastSwappedIndex = -1;
-            }
-
             public T           Current => this.current;
         }
     }

--- a/Core/Collections/Unsafe/UnsafeIntHashMap.cs
+++ b/Core/Collections/Unsafe/UnsafeIntHashMap.cs
@@ -9,7 +9,7 @@ namespace Scellecs.Morpeh.Collections {
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public sealed class UnsafeIntHashMap<T> : IEnumerable<int> where T : unmanaged {
+    public sealed class UnsafeIntHashMap<T> where T : unmanaged {
         public int length;
         public int capacity;
         public int capacityMinusOne;
@@ -50,14 +50,10 @@ namespace Scellecs.Morpeh.Collections {
             return e;
         }
 
-        IEnumerator<int> IEnumerable<int>.GetEnumerator() => this.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-        public unsafe struct Enumerator : IEnumerator<int> {
+        public unsafe struct Enumerator {
             public UnsafeIntHashMap<T> hashMap;
 
             public int index;
@@ -84,16 +80,6 @@ namespace Scellecs.Morpeh.Collections {
             }
 
             public int Current => this.current;
-
-            object IEnumerator.Current => this.current;
-
-            void IEnumerator.Reset() {
-                this.index   = 0;
-                this.current = default;
-            }
-
-            public void Dispose() {
-            }
         }
     }
 }

--- a/Core/Filter.cs
+++ b/Core/Filter.cs
@@ -19,7 +19,7 @@ namespace Scellecs.Morpeh {
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public sealed class Filter : IEnumerable<Entity> {
+    public sealed class Filter {
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
@@ -85,14 +85,10 @@ namespace Scellecs.Morpeh {
             return new EntityEnumerator(this);
         }
 
-        IEnumerator<Entity> IEnumerable<Entity>.GetEnumerator() => this.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-
         [Il2CppSetOption(Option.NullChecks, false)]
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-        public struct EntityEnumerator : IEnumerator<Entity> {
+        public struct EntityEnumerator {
             private readonly FastList<Archetype> archetypes;
             private readonly int                 archetypeCount;
 
@@ -210,47 +206,8 @@ namespace Scellecs.Morpeh {
                 return false;
             }
 
-            public void Reset() {
-                this.current     = null;
-                this.archetypeId = 0;
-                if (this.archetypeCount != 0) {
-                    var currentArchetype = this.archetypes.data[0];
-                    
-                    this.currentArchetypeIsNative = currentArchetype.usedInNative;
-                    
-                    if (currentArchetype.usedInNative) {
-                        this.archetypeEntitiesNative = currentArchetype.entitiesNative;
-                        this.currentEnumeratorNative = this.archetypeEntitiesNative.GetEnumerator();
-                        
-                        this.archetypeEntities = default;
-                        this.currentEnumerator = default;
-                    }
-                    else {
-                        this.archetypeEntities = currentArchetype.entities;
-                        this.currentEnumerator = this.archetypeEntities.GetEnumerator();
-                        
-                        this.archetypeEntitiesNative = default;
-                        this.currentEnumeratorNative = default;
-                    }
-                }
-                else {
-                    this.currentArchetypeIsNative = false;
-                    
-                    this.archetypeEntitiesNative = default;
-                    this.currentEnumeratorNative = default;
-                    
-                    this.archetypeEntities = default;
-                    this.currentEnumerator = default;
-                }
-            }
-
             [NotNull]
             public Entity Current => this.current;
-
-            object IEnumerator.Current => this.current;
-
-            public void Dispose() {
-            }
         }
     }
 }

--- a/Core/World.cs
+++ b/Core/World.cs
@@ -26,7 +26,7 @@ namespace Scellecs.Morpeh {
         public static World Default => worlds.data[0];
         [NotNull]
         [PublicAPI]
-        internal static FastList<World> worlds = new FastList<World> { null };
+        internal static FastList<World> worlds = new FastList<World>().AddAndReturnThis(null);
         
         [CanBeNull]
         internal static FastList<IWorldPlugin> plugins;


### PR DESCRIPTION
Currently, all usages of IEnumerator<T> & IEnumerable<T> are forcefully calling Dispose() methods in foreach calls in IL2CPP, even if Dispose() is an empty method. Additionally, it causes IL2CPP to generate try/catch block in every foreach call.

Removal of those interfaces breaks LINQ behavior on Filter and all the collections, but saves some performance overhead from try/catch blocks and Dispose calls. IntHashMap required a manual implementation of First, and FastList needed a replacement for collection initializer. Added small workarounds for both.