### PR TITLE
Reduce type initialization checks in hot paths (PinnedArray<T>)

### DIFF
--- a/Core/Collections/BitMap.cs
+++ b/Core/Collections/BitMap.cs
@@ -21,9 +21,9 @@ namespace Scellecs.Morpeh.Collections {
         public int lastIndex;
         public int freeIndex;
 
-        public PinnedArray<int> buckets;
-        public PinnedArray<int> data;
-        public PinnedArray<int> slots;
+        public IntPinnedArray buckets;
+        public IntPinnedArray data;
+        public IntPinnedArray slots;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public BitMap(in int capacity = 0) {
@@ -35,9 +35,9 @@ namespace Scellecs.Morpeh.Collections {
             this.capacityMinusOne = HashHelpers.GetCapacity(capacity);
             this.capacity         = this.capacityMinusOne + 1;
 
-            this.buckets = new PinnedArray<int>(this.capacity);
-            this.slots   = new PinnedArray<int>(this.capacity << 1);
-            this.data    = new PinnedArray<int>(this.capacity);
+            this.buckets = new IntPinnedArray(this.capacity);
+            this.slots   = new IntPinnedArray(this.capacity << 1);
+            this.data    = new IntPinnedArray(this.capacity);
         }
 
         ~BitMap() {

--- a/Core/Collections/BitMapExtensions.cs
+++ b/Core/Collections/BitMapExtensions.cs
@@ -87,7 +87,7 @@ namespace Scellecs.Morpeh.Collections {
             bitmap.slots.Resize(newCapacity << 1);
             bitmap.data.Resize(newCapacity);
 
-            var newBuckets = new PinnedArray<int>(newCapacity);
+            var newBuckets = new IntPinnedArray(newCapacity);
 
             {
                 var slotsPtr = bitmap.slots.ptr;

--- a/Core/Collections/IntFastList.cs
+++ b/Core/Collections/IntFastList.cs
@@ -20,26 +20,26 @@ namespace Scellecs.Morpeh.Collections {
         public int length;
         public int capacity;
 
-        public PinnedArray<int> data;
+        public IntPinnedArray data;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IntFastList() {
             this.capacity = 4;
-            this.data     = new PinnedArray<int>(this.capacity);
+            this.data     = new IntPinnedArray(this.capacity);
             this.length   = 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IntFastList(int capacity) {
             this.capacity = HashHelpers.GetCapacity(capacity);
-            this.data     = new PinnedArray<int>(this.capacity);
+            this.data     = new IntPinnedArray(this.capacity);
             this.length   = 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IntFastList(IntFastList other) {
             this.capacity = other.capacity;
-            this.data     = new PinnedArray<int>(this.capacity);
+            this.data     = new IntPinnedArray(this.capacity);
             this.length   = other.length;
             Array.Copy(other.data.data, 0, this.data.data, 0, this.length);
         }

--- a/Core/Collections/IntHashMap.cs
+++ b/Core/Collections/IntHashMap.cs
@@ -25,7 +25,7 @@ namespace Scellecs.Morpeh.Collections {
         public int lastIndex;
         public int freeIndex;
 
-        public PinnedArray<int> buckets;
+        public IntPinnedArray buckets;
 
         public T[]    data;
         public PinnedArray<IntHashMapSlot> slots;
@@ -39,7 +39,7 @@ namespace Scellecs.Morpeh.Collections {
             this.capacityMinusOne = HashHelpers.GetCapacity(capacity - 1);
             this.capacity         = this.capacityMinusOne + 1;
 
-            this.buckets = new PinnedArray<int>(this.capacity);
+            this.buckets = new IntPinnedArray(this.capacity);
             this.slots   = new PinnedArray<IntHashMapSlot>(this.capacity);
             this.data    = new T[this.capacity];
         }

--- a/Core/Collections/IntHashMapExtensions.cs
+++ b/Core/Collections/IntHashMapExtensions.cs
@@ -16,7 +16,7 @@ namespace Scellecs.Morpeh.Collections {
             hashMap.slots.Resize(newCapacity);
             ArrayHelpers.Grow(ref hashMap.data, newCapacity);
 
-            var newBuckets = new PinnedArray<int>(newCapacity);
+            var newBuckets = new IntPinnedArray(newCapacity);
 
             for (int i = 0, len = hashMap.lastIndex; i < len; ++i) {
                 ref var slot = ref hashMap.slots.ptr[i];
@@ -41,7 +41,7 @@ namespace Scellecs.Morpeh.Collections {
             hashMap.slots.Resize(newCapacity);
             ArrayHelpers.Grow(ref hashMap.data, newCapacity);
 
-            var newBuckets = new PinnedArray<int>(newCapacity);
+            var newBuckets = new IntPinnedArray(newCapacity);
 
             for (int i = 0, len = hashMap.lastIndex; i < len; ++i) {
                 ref var slot = ref hashMap.slots.ptr[i];

--- a/Core/Collections/IntHashSet.cs
+++ b/Core/Collections/IntHashSet.cs
@@ -16,8 +16,8 @@ namespace Scellecs.Morpeh.Collections {
         public int lastIndex;
         public int freeIndex;
 
-        public PinnedArray<int> buckets;
-        public PinnedArray<int> slots;
+        public IntPinnedArray buckets;
+        public IntPinnedArray slots;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IntHashSet() : this(0) {
@@ -31,8 +31,8 @@ namespace Scellecs.Morpeh.Collections {
 
             this.capacityMinusOne = HashHelpers.GetCapacity(capacity);
             this.capacity         = this.capacityMinusOne + 1;
-            this.buckets          = new PinnedArray<int>(this.capacity);
-            this.slots            = new PinnedArray<int>(this.capacity / 2);
+            this.buckets          = new IntPinnedArray(this.capacity);
+            this.slots            = new IntPinnedArray(this.capacity / 2);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Core/Collections/IntHashSetExtensions.cs
+++ b/Core/Collections/IntHashSetExtensions.cs
@@ -35,7 +35,7 @@ namespace Scellecs.Morpeh.Collections {
 
                     hashSet.slots.Resize(newCapacity * 2);
 
-                    var newBuckets = new PinnedArray<int>(newCapacity);
+                    var newBuckets = new IntPinnedArray(newCapacity);
 
                     {
                         var slotsPtr = hashSet.slots.ptr;

--- a/Core/Collections/IntStack.cs
+++ b/Core/Collections/IntStack.cs
@@ -11,12 +11,12 @@ namespace Scellecs.Morpeh.Collections {
         public int length;
         public int capacity;
 
-        public PinnedArray<int> data;
+        public IntPinnedArray data;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IntStack() {
             this.capacity = 4;
-            this.data     = new PinnedArray<int>(this.capacity);
+            this.data     = new IntPinnedArray(this.capacity);
             this.length   = 0;
         }
 

--- a/Core/Collections/LongHashMap.cs
+++ b/Core/Collections/LongHashMap.cs
@@ -23,7 +23,7 @@ namespace Scellecs.Morpeh.Collections {
         public int lastIndex;
         public int freeIndex;
 
-        public PinnedArray<int> buckets;
+        public IntPinnedArray buckets;
 
         public T[]    data;
         public PinnedArray<LongHashMapSlot> slots;
@@ -37,7 +37,7 @@ namespace Scellecs.Morpeh.Collections {
             this.capacityMinusOne = HashHelpers.GetCapacity(capacity - 1);
             this.capacity         = this.capacityMinusOne + 1;
 
-            this.buckets = new PinnedArray<int>(this.capacity);
+            this.buckets = new IntPinnedArray(this.capacity);
             this.slots   = new PinnedArray<LongHashMapSlot>(this.capacity);
             this.data    = new T[this.capacity];
         }

--- a/Core/Collections/LongHashMapExtensions.cs
+++ b/Core/Collections/LongHashMapExtensions.cs
@@ -16,7 +16,7 @@ namespace Scellecs.Morpeh.Collections {
             hashMap.slots.Resize(newCapacity);
             ArrayHelpers.Grow(ref hashMap.data, newCapacity);
 
-            var newBuckets = new PinnedArray<int>(newCapacity);
+            var newBuckets = new IntPinnedArray(newCapacity);
 
             for (int i = 0, len = hashMap.lastIndex; i < len; ++i) {
                 ref var slot = ref hashMap.slots.ptr[i];
@@ -41,7 +41,7 @@ namespace Scellecs.Morpeh.Collections {
             hashMap.slots.Resize(newCapacity);
             ArrayHelpers.Grow(ref hashMap.data, newCapacity);
 
-            var newBuckets = new PinnedArray<int>(newCapacity);
+            var newBuckets = new IntPinnedArray(newCapacity);
 
             for (int i = 0, len = hashMap.lastIndex; i < len; ++i) {
                 ref var slot = ref hashMap.slots.ptr[i];

--- a/Core/Collections/Unsafe/IntPinnedArray.cs
+++ b/Core/Collections/Unsafe/IntPinnedArray.cs
@@ -1,0 +1,103 @@
+#if ENABLE_MONO || ENABLE_IL2CPP
+#define MORPEH_UNITY
+#endif
+
+namespace Scellecs.Morpeh.Collections {
+    using System;
+    using System.Runtime.CompilerServices;
+#if MORPEH_UNITY
+    using Unity.Collections.LowLevel.Unsafe;
+#else
+    using System.Runtime.InteropServices;
+#endif
+    using Unity.IL2CPP.CompilerServices;
+
+    [Serializable]
+    [Il2CppSetOption(Option.NullChecks, false)]
+    [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
+    [Il2CppSetOption(Option.DivideByZeroChecks, false)]
+    public unsafe struct IntPinnedArray : IDisposable {
+        public int[] data;
+        public int* ptr;
+#if MORPEH_UNITY
+        public ulong handle;
+#else
+        public GCHandle handle;
+#endif
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IntPinnedArray(int size) {
+            this.data = new int[size];
+#if MORPEH_UNITY
+            this.ptr = (int*) UnsafeUtility.PinGCArrayAndGetDataAddress(this.data, out this.handle);
+#else
+            this.handle = GCHandle.Alloc(this.data, GCHandleType.Pinned);
+            this.ptr = (int*)this.handle.AddrOfPinnedObject();
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Resize(int newSize) {
+#if MORPEH_UNITY
+            UnsafeUtility.ReleaseGCObject(this.handle);
+#else
+            this.handle.Free();
+#endif
+            var newArray = new int[newSize];
+            var len = this.data.Length;
+            Array.Copy(this.data, 0, newArray, 0, newSize >= len ? len : newSize);
+            this.data = newArray;
+#if MORPEH_UNITY
+            this.ptr = (int*) UnsafeUtility.PinGCArrayAndGetDataAddress(this.data, out this.handle);
+#else
+            this.handle = GCHandle.Alloc(newArray, GCHandleType.Pinned);
+            this.ptr = (int*)this.handle.AddrOfPinnedObject();
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Clear() {
+            Array.Clear(this.data, 0, this.data.Length);
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose() {
+#if MORPEH_UNITY
+            UnsafeUtility.ReleaseGCObject(this.handle);
+            this.ptr = (int*)IntPtr.Zero;
+            this.data = null;
+#else
+            if (this.handle.IsAllocated) {
+                this.handle.Free();
+                this.ptr = (int*)IntPtr.Zero;
+                this.data = null;
+            }
+#endif
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Enumerator GetEnumerator() {
+            Enumerator e;
+            e.lengthMinusOne = this.data.Length - 1;
+            e.ptr    = this.ptr;
+            e.index   = -1;
+            return e;
+        }
+
+        [Il2CppSetOption(Option.NullChecks, false)]
+        [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
+        [Il2CppSetOption(Option.DivideByZeroChecks, false)]
+        public struct Enumerator {
+            public int* ptr;
+
+            public int lengthMinusOne;
+            public int index;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool MoveNext() {
+                return ++this.index <= this.lengthMinusOne;
+            }
+            
+            public int Current => this.ptr[this.index];
+        }
+    }
+}

--- a/Core/Collections/Unsafe/IntPinnedArray.cs.meta
+++ b/Core/Collections/Unsafe/IntPinnedArray.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ee54d5b98f9b482c89771eecf6ca9a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Core/Collections/Unsafe/UnsafeIntHashMap.cs
+++ b/Core/Collections/Unsafe/UnsafeIntHashMap.cs
@@ -16,7 +16,7 @@ namespace Scellecs.Morpeh.Collections {
         public int lastIndex;
         public int freeIndex;
 
-        public PinnedArray<int> buckets;
+        public IntPinnedArray buckets;
 
         public PinnedArray<T>   data;
         public PinnedArray<IntHashMapSlot> slots;
@@ -30,7 +30,7 @@ namespace Scellecs.Morpeh.Collections {
             this.capacityMinusOne = HashHelpers.GetCapacity(capacity);
             this.capacity         = this.capacityMinusOne + 1;
 
-            this.buckets = new PinnedArray<int>(this.capacity);
+            this.buckets = new IntPinnedArray(this.capacity);
             this.slots   = new PinnedArray<IntHashMapSlot>(this.capacity);
             this.data    = new PinnedArray<T>(this.capacity);
         }

--- a/Core/Collections/Unsafe/UnsafeIntHashMapExtensions.cs
+++ b/Core/Collections/Unsafe/UnsafeIntHashMapExtensions.cs
@@ -15,7 +15,7 @@ namespace Scellecs.Morpeh.Collections {
             hashMap.slots.Resize(newCapacity);
             hashMap.data.Resize(newCapacity);
 
-            var newBuckets = new PinnedArray<int>(newCapacity);
+            var newBuckets = new IntPinnedArray(newCapacity);
 
             {
                 var slotsPtr = hashMap.slots.ptr;


### PR DESCRIPTION
Generic calls require metadata initialization in il2cpp. By implementing a raw IntPinnedArray without any generics we can bypass metadata initialization checks for hot paths. This will get rid of at least some "if" checks.

Before: 
<img width="1029" alt="image" src="https://user-images.githubusercontent.com/7792608/233499334-e09a4463-b4ec-493e-9af3-9572ede42470.png">


After:
<img width="317" alt="image" src="https://user-images.githubusercontent.com/7792608/233499738-605ef70c-56fa-4f48-b6f0-39d5a5d23a14.png">
