### PR TITLE
Add FIlter implicit operator to implicitly build FilterBuilder

### DIFF
--- a/Core/Filter.cs
+++ b/Core/Filter.cs
@@ -191,5 +191,6 @@ namespace Scellecs.Morpeh {
             void IEnumerator.Reset() {}
 #endif
         }
+        public static implicit operator Filter(FilterBuilder builder) => builder.Build();
     }
 }


### PR DESCRIPTION
This add-on should not create unnecessary garbage. It is just an auto-conversion that the user does anyway.


