### PR TITLE
Reduce Il2cppMemoryAllocator memory usage from generics

### DIFF
--- a/Core/Stash.cs
+++ b/Core/Stash.cs
@@ -89,7 +89,7 @@ namespace Scellecs.Morpeh {
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
     public sealed class Stash<T> : Stash where T : struct, IComponent {
-        internal static FastList<Stash<T>> typedStashes;
+        internal static FastList<Stash> typedStashes;
         // ReSharper disable once StaticMemberInGenericType
         internal static IntStack typedStashesFreeIds;
 
@@ -106,7 +106,7 @@ namespace Scellecs.Morpeh {
                 typedStashes.Clear();
                 typedStashesFreeIds.Clear();
             };
-            typedStashes = new FastList<Stash<T>>();
+            typedStashes = new FastList<Stash>();
             typedStashesFreeIds = new IntStack();
             
         }

--- a/Core/WorldExtensions.cs
+++ b/Core/WorldExtensions.cs
@@ -168,7 +168,7 @@ namespace Scellecs.Morpeh {
             
             var info = TypeIdentifier<T>.info;
             if (world.typedStashes.TryGetValue(info.id, out var typedIndex)) {
-                return Stash<T>.typedStashes.data[typedIndex];
+                return (Stash<T>)Stash<T>.typedStashes.data[typedIndex];
             }
 
             var stash = new Stash<T>();


### PR DESCRIPTION
![img](https://i.imgur.com/Omx01rT.png)