### PR TITLE
Devirtualize stashes

### DIFF
--- a/Core/Native/NativeIntHashMapExtensions.cs
+++ b/Core/Native/NativeIntHashMapExtensions.cs
@@ -32,7 +32,6 @@ namespace Scellecs.Morpeh.Native {
             return nativeIntHashMap;
         }
         
-        
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ref TNative GetValueRefByKey<TNative>(this ref NativeIntHashMap<TNative> nativeIntHashMap, in int key) where TNative : unmanaged {
             var rem = key & *nativeIntHashMap.capacityMinusOnePtr;

--- a/Core/Native/NativeStashExtensions.cs
+++ b/Core/Native/NativeStashExtensions.cs
@@ -6,11 +6,34 @@ namespace Scellecs.Morpeh.Native {
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public static class NativeStashExtensions {
+    public static unsafe class NativeStashExtensions {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static NativeIntHashMap<TNative> AsNativeIntHashMap<TNative>(this Stash<TNative> hashMap) where TNative : unmanaged, IComponent {
+            var nativeIntHashMap = new NativeIntHashMap<TNative>();
+            
+            fixed (int* lengthPtr = &hashMap.map.length)
+            fixed (int* capacityPtr = &hashMap.map.capacity)
+            fixed (int* capacityMinusOnePtr = &hashMap.map.capacityMinusOne)
+            fixed (int* lastIndexPtr = &hashMap.map.lastIndex)
+            fixed (int* freeIndexPtr = &hashMap.map.freeIndex)
+            fixed (TNative* dataPtr = &hashMap.data[0]) {
+                nativeIntHashMap.lengthPtr           = lengthPtr;
+                nativeIntHashMap.capacityPtr         = capacityPtr;
+                nativeIntHashMap.capacityMinusOnePtr = capacityMinusOnePtr;
+                nativeIntHashMap.lastIndexPtr        = lastIndexPtr;
+                nativeIntHashMap.freeIndexPtr        = freeIndexPtr;
+                nativeIntHashMap.data                = dataPtr;
+                nativeIntHashMap.buckets             = hashMap.map.buckets.ptr;
+                nativeIntHashMap.slots               = hashMap.map.slots.ptr;
+            }
+
+            return nativeIntHashMap;
+        }
+        
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static NativeStash<TNative> AsNative<TNative>(this Stash<TNative> stash) where TNative : unmanaged, IComponent {
             var nativeCache = new NativeStash<TNative> {
-                components = stash.components.AsNative(),
+                components = stash.AsNativeIntHashMap(),
                 world = stash.world.AsNative(),
             };
             return nativeCache;

--- a/Core/Stash.cs
+++ b/Core/Stash.cs
@@ -106,11 +106,11 @@ namespace Scellecs.Morpeh {
         [PublicAPI]
         public bool IsDisposed;
 
-        internal World world;
-        internal long typeId;
-        internal int offset;
+        private World world;
+        private long typeId;
+        private int offset;
         
-        internal StashMap map;
+        internal readonly StashMap map;
         public T[] data;
         private T empty;
 

--- a/Core/Stash.cs
+++ b/Core/Stash.cs
@@ -18,8 +18,8 @@ namespace Scellecs.Morpeh {
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
     public class Stash : IDisposable {
-        private StashMap stashMap;
-        private IDisposable typelessStash;
+        internal StashMap stashMap;
+        internal IDisposable typelessStash;
         
         internal long typeId;
         
@@ -55,11 +55,6 @@ namespace Scellecs.Morpeh {
             };
         }
         
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Stash<T> GetTypedStash<T>() where T : struct, IComponent {
-            return (Stash<T>)this.typelessStash;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Set(Entity entity) {
             this.setReflection(entity);

--- a/Core/Stash.cs
+++ b/Core/Stash.cs
@@ -217,7 +217,7 @@ namespace Scellecs.Morpeh {
                 throw new Exception($"[MORPEH] You're trying to get on entity {entity.entityId.id} a component that doesn't exists!");
             }
 #endif
-            if (this.map.TryGetIndex(in entity.entityId.id, out var dataIndex)) {
+            if (this.map.TryGetIndex(entity.entityId.id, out var dataIndex)) {
                 return ref this.data[dataIndex];
             }
             
@@ -233,7 +233,7 @@ namespace Scellecs.Morpeh {
                 throw new Exception($"[MORPEH] You are trying Get on null or disposed entity");
             }
 #endif
-            if (this.map.TryGetIndex(in entity.entityId.id, out var dataIndex))
+            if (this.map.TryGetIndex(entity.entityId.id, out var dataIndex))
             {
                 exist = true;
                 return ref this.data[dataIndex];
@@ -376,7 +376,7 @@ namespace Scellecs.Morpeh {
             var previousCapacity = this.map.capacity;
 #endif
 
-            if (this.map.TryGetIndex(in from.entityId.id, out var dataIndex)) {
+            if (this.map.TryGetIndex(from.entityId.id, out var dataIndex)) {
                 var component = this.data[dataIndex];
                 
                 if (overwrite) {

--- a/Core/Stash.cs
+++ b/Core/Stash.cs
@@ -331,11 +331,9 @@ namespace Scellecs.Morpeh {
                     this.world.GetEntity(entityId).RemoveTransfer(this.typeId, this.offset);
                 }
             }
-
-            if (!this.map.IsEmpty()) {
-                Array.Clear(this.data, 0, this.map.capacity);
-                this.map.Clear();
-            }
+            
+            Array.Clear(this.data, 0, this.map.capacity);
+            this.map.Clear();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Core/Stash.cs
+++ b/Core/Stash.cs
@@ -17,72 +17,117 @@ namespace Scellecs.Morpeh {
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public abstract class Stash : IDisposable {
-        [PublicAPI]
-        public bool IsDisposed;
-
+    public class Stash : IDisposable {
+        private StashMap stashMap;
+        private IDisposable typelessStash;
+        
         internal long typeId;
-        internal int offset;
-        internal World world;
+        
+        private Action<Entity> setReflection;
+        private Func<Entity, bool> removeReflection;
+        private Func<Entity, bool> cleanReflection;
+        private Action removeAllReflection;
+        private Action<Entity, Entity, bool> migrateReflection;
+        
+        private Stash() { }
+
+        public static Stash CreateReflection(World world, Type type) {
+            var createMethod = typeof(Stash).GetMethod("Create", new[] { typeof(World), });
+            var genericMethod = createMethod?.MakeGenericMethod(type);
+            return (Stash)genericMethod?.Invoke(null, new object[] { world, });
+        }
+
+        public static Stash Create<T>(World world) where T : struct, IComponent {
+            var info = TypeIdentifier<T>.info;
+            var stash = new Stash<T>(world, info);
+            
+            return new Stash {
+                stashMap = stash.map,
+                typelessStash = stash,
+                
+                typeId = info.id,
+                
+                setReflection = stash.Set,
+                removeReflection = stash.Remove,
+                cleanReflection = stash.Clean,
+                removeAllReflection = stash.RemoveAll,
+                migrateReflection = stash.Migrate,
+            };
+        }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public abstract void Set(Entity entity);
+        public Stash<T> GetTypedStash<T>() where T : struct, IComponent {
+            return (Stash<T>)this.typelessStash;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public abstract bool Remove(Entity entity);
+        public void Set(Entity entity) {
+            this.setReflection(entity);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public abstract void RemoveAll();
+        public bool Remove(Entity entity) {
+            return this.removeReflection(entity);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal abstract bool Clean(Entity entity);
+        public void RemoveAll() {
+            this.removeAllReflection();
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public abstract bool Has(Entity entity);
+        internal bool Clean(Entity entity) {
+            return this.cleanReflection(entity);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public abstract void Migrate(Entity from, Entity to, bool overwrite = true);
+        public void Migrate(Entity from, Entity to, bool overwrite = true) {
+            this.migrateReflection(from, to, overwrite);
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Has(Entity entity) {
+            return this.stashMap.Has(entity.entityId.id);
+        }
 
-        public abstract void Dispose();
+        public void Dispose() {
+            this.typelessStash.Dispose();
+        }
     }
 
     [Il2CppEagerStaticClassConstruction]
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public sealed class Stash<T> : Stash where T : struct, IComponent {
+    public sealed class Stash<T> : IDisposable where T : struct, IComponent {
 #if !MORPEH_DISABLE_COMPONENT_DISPOSE
         internal delegate void ComponentDispose(ref T component);
 #endif
+        [PublicAPI]
+        public bool IsDisposed;
 
-        internal T empty;
-        internal IntHashMap<T> components;
+        internal World world;
+        internal long typeId;
+        internal int offset;
+        
+        internal StashMap map;
+        public T[] data;
+        private T empty;
 
 #if !MORPEH_DISABLE_COMPONENT_DISPOSE
         internal ComponentDispose componentDispose;
 #endif
-        
-        [UnityEngine.Scripting.Preserve]
-        internal Stash() : this(-1) { }
 
         [UnityEngine.Scripting.Preserve]
-        public Stash(int capacity = -1) {
-            var info = TypeIdentifier<T>.info;
+        internal Stash(World world, CommonTypeIdentifier.TypeInfo typeInfo, int capacity = -1) {
+            this.world = world;
+            this.typeId = typeInfo.id;
+            this.offset = typeInfo.offset;
             
-            this.typeId = info.id;
-            this.offset = info.offset;
-
-            this.components = new IntHashMap<T>(capacity < 0 ? info.stashSize : capacity);
-        }
-
-        internal Stash(Stash<T> other) {
-            this.typeId = other.typeId;
-            this.offset = other.offset;
+            this.map = new StashMap(capacity < 0 ? typeInfo.stashSize : capacity);
+            this.data = new T[this.map.capacity];
             
-            this.components = new IntHashMap<T>(other.components);
-#if !MORPEH_DISABLE_COMPONENT_DISPOSE
-            this.componentDispose = other.componentDispose;
-#endif
+            this.empty = default;
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -94,16 +139,16 @@ namespace Scellecs.Morpeh {
                 throw new Exception($"[MORPEH] You are trying Add on null or disposed entity");
             }
 
-            var previousCapacity = this.components.capacity;
+            var previousCapacity = this.map.capacity;
 #endif
-            if (this.components.Add(entity.entityId.id, default, out var slotIndex)) {
+            if (this.TryAddData(entity.entityId.id, default, out var slotIndex)) {
                 entity.AddTransfer(this.typeId, this.offset);
 #if MORPEH_DEBUG
-                if (previousCapacity != this.components.capacity) {
+                if (previousCapacity != this.map.capacity) {
                     world.newMetrics.stashResizes++;
                 }
 #endif
-                return ref this.components.data[slotIndex];
+                return ref this.data[slotIndex];
             }
 #if MORPEH_DEBUG
             MLogger.LogError($"You're trying to add on entity {entity.entityId.id} a component that already exists! Use Get or Set instead!");
@@ -120,17 +165,17 @@ namespace Scellecs.Morpeh {
                 throw new Exception($"[MORPEH] You are trying Add on null or disposed entity");
             }
             
-            var previousCapacity = this.components.capacity;
+            var previousCapacity = this.map.capacity;
 #endif
-            if (this.components.Add(entity.entityId.id, default, out var slotIndex)) {
+            if (this.TryAddData(entity.entityId.id, default, out var slotIndex)) {
                 entity.AddTransfer(this.typeId, this.offset);
                 exist = false;
 #if MORPEH_DEBUG
-                if (previousCapacity != this.components.capacity) {
+                if (previousCapacity != this.map.capacity) {
                     world.newMetrics.stashResizes++;
                 }
 #endif
-                return ref this.components.data[slotIndex];
+                return ref this.data[slotIndex];
             }
 
             exist = true;
@@ -146,12 +191,12 @@ namespace Scellecs.Morpeh {
                 throw new Exception($"[MORPEH] You are trying Add on null or disposed entity");
             }
             
-            var previousCapacity = this.components.capacity;
+            var previousCapacity = this.map.capacity;
 #endif
-            if (this.components.Add(entity.entityId.id, value, out _)) {
+            if (this.TryAddData(entity.entityId.id, value, out _)) {
                 entity.AddTransfer(this.typeId, this.offset);
 #if MORPEH_DEBUG
-                if (previousCapacity != this.components.capacity) {
+                if (previousCapacity != this.map.capacity) {
                     world.newMetrics.stashResizes++;
                 }
 #endif
@@ -173,11 +218,15 @@ namespace Scellecs.Morpeh {
                 throw new Exception($"[MORPEH] You are trying Get on null or disposed entity");
             }
 
-            if (!this.components.Has(entity.entityId.id)) {
+            if (!this.map.Has(entity.entityId.id)) {
                 throw new Exception($"[MORPEH] You're trying to get on entity {entity.entityId.id} a component that doesn't exists!");
             }
 #endif
-            return ref this.components.GetValueRefByKey(entity.entityId.id);
+            if (this.map.TryGetIndex(in entity.entityId.id, out var dataIndex)) {
+                return ref this.data[dataIndex];
+            }
+            
+            return ref this.empty;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -189,11 +238,18 @@ namespace Scellecs.Morpeh {
                 throw new Exception($"[MORPEH] You are trying Get on null or disposed entity");
             }
 #endif
-            return ref this.components.TryGetValueRefByKey(entity.entityId.id, out exist);
+            if (this.map.TryGetIndex(in entity.entityId.id, out var dataIndex))
+            {
+                exist = true;
+                return ref this.data[dataIndex];
+            }
+            
+            exist = false;
+            return ref this.empty;
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override void Set(Entity entity) {
+        public void Set(Entity entity) {
             world.ThreadSafetyCheck();
             
 #if MORPEH_DEBUG
@@ -201,12 +257,12 @@ namespace Scellecs.Morpeh {
                 throw new Exception($"[MORPEH] You are trying Set on null or disposed entity");
             }
             
-            var previousCapacity = this.components.capacity;
+            var previousCapacity = this.map.capacity;
 #endif
 
-            if (this.components.Set(entity.entityId.id, default, out _)) {
+            if (this.TrySetData(entity.entityId.id, default)) {
 #if MORPEH_DEBUG
-                if (previousCapacity != this.components.capacity) {
+                if (previousCapacity != this.map.capacity) {
                     world.newMetrics.stashResizes++;
                 }
 #endif
@@ -222,12 +278,12 @@ namespace Scellecs.Morpeh {
             if (entity.IsNullOrDisposed()) {
                 throw new Exception($"[MORPEH] You are trying Set on null or disposed entity");
             }
-            var previousCapacity = this.components.capacity;
+            var previousCapacity = this.map.capacity;
 #endif
 
-            if (this.components.Set(entity.entityId.id, value, out _)) {
+            if (this.TrySetData(entity.entityId.id, value)) {
 #if MORPEH_DEBUG
-                if (previousCapacity != this.components.capacity) {
+                if (previousCapacity != this.map.capacity) {
                     world.newMetrics.stashResizes++;
                 }
 #endif
@@ -239,7 +295,7 @@ namespace Scellecs.Morpeh {
         internal ref T Empty() => ref this.empty;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override bool Remove(Entity entity) {
+        public bool Remove(Entity entity) {
             world.ThreadSafetyCheck();
             
 #if MORPEH_DEBUG
@@ -248,46 +304,50 @@ namespace Scellecs.Morpeh {
             }
 #endif
 
-            if (this.components.Remove(entity.entityId.id, out var lastValue)) {
+            if (this.map.Remove(entity.entityId.id, out var slotIndex)) {
                 entity.RemoveTransfer(this.typeId, this.offset);
 #if !MORPEH_DISABLE_COMPONENT_DISPOSE
-                this.componentDispose?.Invoke(ref lastValue);
+                this.componentDispose?.Invoke(ref this.data[slotIndex]);
 #endif
                 return true;
             }
+            
             return false;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override void RemoveAll() {
+        public void RemoveAll() {
             world.ThreadSafetyCheck();
 
 #if !MORPEH_DISABLE_COMPONENT_DISPOSE
             if (this.componentDispose != null) {
-                foreach (var index in this.components) {
-                    this.componentDispose.Invoke(ref this.components.data[index]);
+                foreach (var index in this) {
+                    this.componentDispose.Invoke(ref this.data[index]);
 
-                    var entityId = this.components.GetKeyByIndex(index);
+                    var entityId = this.map.GetKeyByIndex(index);
                     this.world.GetEntity(entityId).RemoveTransfer(this.typeId, this.offset);
                 }
             } 
             else 
 #endif
             {
-                foreach (var index in this.components) {
-                    var entityId = this.components.GetKeyByIndex(index);
+                foreach (var index in this) {
+                    var entityId = this.map.GetKeyByIndex(index);
                     this.world.GetEntity(entityId).RemoveTransfer(this.typeId, this.offset);
                 }
             }
 
-            this.components.Clear();
+            if (!this.map.IsEmpty()) {
+                Array.Clear(this.data, 0, this.map.capacity);
+                this.map.Clear();
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override bool Clean(Entity entity) {
-            if (this.components.Remove(entity.entityId.id, out var lastValue)) {
+        internal bool Clean(Entity entity) {
+            if (this.map.Remove(entity.entityId.id, out var slotIndex)) {
 #if !MORPEH_DISABLE_COMPONENT_DISPOSE
-                this.componentDispose?.Invoke(ref lastValue);
+                this.componentDispose?.Invoke(ref this.data[slotIndex]);
 #endif
                 return true;
             }
@@ -295,7 +355,7 @@ namespace Scellecs.Morpeh {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override bool Has(Entity entity) {
+        public bool Has(Entity entity) {
             world.ThreadSafetyCheck();
             
 #if MORPEH_DEBUG
@@ -304,11 +364,11 @@ namespace Scellecs.Morpeh {
             }
 #endif
 
-            return this.components.Has(entity.entityId.id);
+            return this.map.Has(entity.entityId.id);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override void Migrate(Entity from, Entity to, bool overwrite = true) {
+        public void Migrate(Entity from, Entity to, bool overwrite = true) {
             world.ThreadSafetyCheck();
             
 #if MORPEH_DEBUG
@@ -318,34 +378,36 @@ namespace Scellecs.Morpeh {
             if (to.IsNullOrDisposed()) {
                 throw new Exception($"[MORPEH] You are trying Migrate TO null or disposed entity");
             }
-            var previousCapacity = this.components.capacity;
+            var previousCapacity = this.map.capacity;
 #endif
 
-            if (this.components.TryGetValue(from.entityId.id, out var component)) {
+            if (this.map.TryGetIndex(in from.entityId.id, out var dataIndex)) {
+                var component = this.data[dataIndex];
+                
                 if (overwrite) {
-                    if (this.components.Has(to.entityId.id)) {
-                        this.components.Set(to.entityId.id, component, out _);
+                    if (this.map.Has(to.entityId.id)) {
+                        this.TrySetData(to.entityId.id, component);
                     }
                     else {
-                        if (this.components.Add(to.entityId.id, component, out _)) {
+                        if (this.TryAddData(to.entityId.id, component, out _)) {
                             to.AddTransfer(this.typeId, this.offset);
                         }
                     }
                 }
                 else {
-                    if (this.components.Has(to.entityId.id) == false) {
-                        if (this.components.Add(to.entityId.id, component, out _)) {
+                    if (this.map.Has(to.entityId.id) == false) {
+                        if (this.TryAddData(to.entityId.id, component, out _)) {
                             to.AddTransfer(this.typeId, this.offset);
                         }
                     }
                 }
 
-                if (this.components.Remove(from.entityId.id, out _)) {
+                if (this.map.Remove(from.entityId.id, out _)) {
                     from.RemoveTransfer(this.typeId, this.offset);
                 }
             }
 #if MORPEH_DEBUG
-            if (previousCapacity != this.components.capacity) {
+            if (previousCapacity != this.map.capacity) {
                 world.newMetrics.stashResizes++;
             }
 #endif
@@ -355,17 +417,17 @@ namespace Scellecs.Morpeh {
         public bool IsEmpty() {
             world.ThreadSafetyCheck();
             
-            return this.components.length == 0;
+            return this.map.length == 0;
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsNotEmpty() {
             world.ThreadSafetyCheck();
             
-            return this.components.length != 0;
+            return this.map.length != 0;
         }
 
-        public override void Dispose() {
+        public void Dispose() {
             if (this.IsDisposed) {
                 return;
             }
@@ -374,19 +436,60 @@ namespace Scellecs.Morpeh {
             
 #if !MORPEH_DISABLE_COMPONENT_DISPOSE
             if (this.componentDispose != null) {
-                foreach (var componentId in this.components) {
-                    this.componentDispose.Invoke(ref this.components.data[componentId]);
+                foreach (var componentId in this) {
+                    this.componentDispose.Invoke(ref this.data[componentId]);
                 }
             }
 #endif
 
-            this.components.Clear();
-            this.components = null;
+            if (!this.map.IsEmpty()) {
+                Array.Clear(this.data, 0, this.map.capacity);
+                this.map.Clear();
+            }
             
 #if !MORPEH_DISABLE_COMPONENT_DISPOSE
             this.componentDispose = null;
 #endif
             this.IsDisposed = true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Enumerator GetEnumerator() {
+            Enumerator e;
+            e.stash = this;
+            e.index   = 0;
+            e.current = default;
+            return e;
+        }
+
+        [Il2CppSetOption(Option.NullChecks, false)]
+        [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
+        [Il2CppSetOption(Option.DivideByZeroChecks, false)]
+        public unsafe struct Enumerator {
+            public Stash<T> stash;
+
+            public int index;
+            public int current;
+
+            public bool MoveNext() {
+                for (; this.index < this.stash.map.lastIndex; ++this.index) {
+                    ref var slot = ref this.stash.map.slots.ptr[this.index];
+                    if (slot.key - 1 < 0) {
+                        continue;
+                    }
+
+                    this.current = this.index;
+                    ++this.index;
+
+                    return true;
+                }
+
+                this.index   = this.stash.map.lastIndex + 1;
+                this.current = default;
+                return false;
+            }
+
+            public int Current => this.current;
         }
     }
 

--- a/Core/Stash.cs
+++ b/Core/Stash.cs
@@ -18,7 +18,7 @@ namespace Scellecs.Morpeh {
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
     public class Stash : IDisposable {
-        internal StashMap stashMap;
+        internal StashMap map;
         internal IDisposable typelessStash;
         
         internal long typeId;
@@ -42,7 +42,7 @@ namespace Scellecs.Morpeh {
             var stash = new Stash<T>(world, info);
             
             return new Stash {
-                stashMap = stash.map,
+                map = stash.map,
                 typelessStash = stash,
                 
                 typeId = info.id,
@@ -82,7 +82,7 @@ namespace Scellecs.Morpeh {
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Has(Entity entity) {
-            return this.stashMap.Has(entity.entityId.id);
+            return this.map.Has(entity.entityId.id);
         }
 
         public void Dispose() {

--- a/Core/Stash.cs
+++ b/Core/Stash.cs
@@ -316,7 +316,7 @@ namespace Scellecs.Morpeh {
 
 #if !MORPEH_DISABLE_COMPONENT_DISPOSE
             if (this.componentDispose != null) {
-                foreach (var index in this) {
+                foreach (var index in this.map) {
                     this.componentDispose.Invoke(ref this.data[index]);
 
                     var entityId = this.map.GetKeyByIndex(index);
@@ -326,7 +326,7 @@ namespace Scellecs.Morpeh {
             else 
 #endif
             {
-                foreach (var index in this) {
+                foreach (var index in this.map) {
                     var entityId = this.map.GetKeyByIndex(index);
                     this.world.GetEntity(entityId).RemoveTransfer(this.typeId, this.offset);
                 }
@@ -431,7 +431,7 @@ namespace Scellecs.Morpeh {
             
 #if !MORPEH_DISABLE_COMPONENT_DISPOSE
             if (this.componentDispose != null) {
-                foreach (var componentId in this) {
+                foreach (var componentId in this.map) {
                     this.componentDispose.Invoke(ref this.data[componentId]);
                 }
             }
@@ -447,45 +447,5 @@ namespace Scellecs.Morpeh {
 #endif
             this.IsDisposed = true;
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Enumerator GetEnumerator() {
-            Enumerator e;
-            e.map = this.map;
-            e.index = 0;
-            e.current = default;
-            return e;
-        }
-
-        [Il2CppSetOption(Option.NullChecks, false)]
-        [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
-        [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-        public unsafe struct Enumerator {
-            public StashMap map;
-
-            public int index;
-            public int current;
-
-            public bool MoveNext() {
-                for (; this.index < this.map.lastIndex; ++this.index) {
-                    var slot = this.map.slots.ptr[this.index];
-                    if (slot.key - 1 < 0) {
-                        continue;
-                    }
-
-                    this.current = this.index;
-                    ++this.index;
-
-                    return true;
-                }
-
-                this.index = this.map.lastIndex + 1;
-                this.current = default;
-                return false;
-            }
-
-            public int Current => this.current;
-        }
     }
-
 }

--- a/Core/Stash.cs
+++ b/Core/Stash.cs
@@ -451,8 +451,8 @@ namespace Scellecs.Morpeh {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Enumerator GetEnumerator() {
             Enumerator e;
-            e.stash = this;
-            e.index   = 0;
+            e.map = this.map;
+            e.index = 0;
             e.current = default;
             return e;
         }
@@ -461,14 +461,14 @@ namespace Scellecs.Morpeh {
         [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
         [Il2CppSetOption(Option.DivideByZeroChecks, false)]
         public unsafe struct Enumerator {
-            public Stash<T> stash;
+            public StashMap map;
 
             public int index;
             public int current;
 
             public bool MoveNext() {
-                for (; this.index < this.stash.map.lastIndex; ++this.index) {
-                    ref var slot = ref this.stash.map.slots.ptr[this.index];
+                for (; this.index < this.map.lastIndex; ++this.index) {
+                    var slot = this.map.slots.ptr[this.index];
                     if (slot.key - 1 < 0) {
                         continue;
                     }
@@ -479,7 +479,7 @@ namespace Scellecs.Morpeh {
                     return true;
                 }
 
-                this.index   = this.stash.map.lastIndex + 1;
+                this.index = this.map.lastIndex + 1;
                 this.current = default;
                 return false;
             }

--- a/Core/Stash.cs
+++ b/Core/Stash.cs
@@ -447,5 +447,29 @@ namespace Scellecs.Morpeh {
 #endif
             this.IsDisposed = true;
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Enumerator GetEnumerator() {
+            return new Enumerator {
+                mapEnumerator = this.map.GetEnumerator(),
+                data = this.data,
+            };
+        }
+            
+        [Il2CppSetOption(Option.NullChecks, false)]
+        [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
+        [Il2CppSetOption(Option.DivideByZeroChecks, false)]
+        public struct Enumerator {
+            internal StashMap.Enumerator mapEnumerator;
+            internal T[] data;
+            
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool MoveNext() => this.mapEnumerator.MoveNext();
+            
+            public ref T Current {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => ref this.data[this.mapEnumerator.Current];
+            }
+        }
     }
 }

--- a/Core/Stash.cs
+++ b/Core/Stash.cs
@@ -101,7 +101,7 @@ namespace Scellecs.Morpeh {
         [PublicAPI]
         public bool IsDisposed;
 
-        private World world;
+        internal World world;
         private long typeId;
         private int offset;
         

--- a/Core/Stash.cs
+++ b/Core/Stash.cs
@@ -316,18 +316,18 @@ namespace Scellecs.Morpeh {
 
 #if !MORPEH_DISABLE_COMPONENT_DISPOSE
             if (this.componentDispose != null) {
-                foreach (var index in this.map) {
-                    this.componentDispose.Invoke(ref this.data[index]);
+                foreach (var slotIndex in this.map) {
+                    this.componentDispose.Invoke(ref this.data[slotIndex]);
 
-                    var entityId = this.map.GetKeyByIndex(index);
+                    var entityId = this.map.GetKeyBySlotIndex(slotIndex);
                     this.world.GetEntity(entityId).RemoveTransfer(this.typeId, this.offset);
                 }
             } 
             else 
 #endif
             {
-                foreach (var index in this.map) {
-                    var entityId = this.map.GetKeyByIndex(index);
+                foreach (var slotIndex in this.map) {
+                    var entityId = this.map.GetKeyBySlotIndex(slotIndex);
                     this.world.GetEntity(entityId).RemoveTransfer(this.typeId, this.offset);
                 }
             }
@@ -376,8 +376,8 @@ namespace Scellecs.Morpeh {
             var previousCapacity = this.map.capacity;
 #endif
 
-            if (this.map.TryGetIndex(from.entityId.id, out var dataIndex)) {
-                var component = this.data[dataIndex];
+            if (this.map.TryGetIndex(from.entityId.id, out var slotIndex)) {
+                var component = this.data[slotIndex];
                 
                 if (overwrite) {
                     if (this.map.Has(to.entityId.id)) {
@@ -431,8 +431,8 @@ namespace Scellecs.Morpeh {
             
 #if !MORPEH_DISABLE_COMPONENT_DISPOSE
             if (this.componentDispose != null) {
-                foreach (var componentId in this.map) {
-                    this.componentDispose.Invoke(ref this.data[componentId]);
+                foreach (var slotIndex in this.map) {
+                    this.componentDispose.Invoke(ref this.data[slotIndex]);
                 }
             }
 #endif

--- a/Core/StashExtensions.cs
+++ b/Core/StashExtensions.cs
@@ -18,7 +18,7 @@ namespace Scellecs.Morpeh {
                 return false;
             }
 
-            slotIndex = stash.map.TakeSlot(in key, out var resized);
+            slotIndex = stash.map.TakeSlot(key, out var resized);
             
             if (resized) {
                 ArrayHelpers.Grow(ref stash.data, stash.map.capacity);
@@ -35,7 +35,7 @@ namespace Scellecs.Morpeh {
                 return false;
             }
 
-            slotIndex = stash.map.TakeSlot(in key, out var resized);
+            slotIndex = stash.map.TakeSlot(key, out var resized);
             
             if (resized) {
                 ArrayHelpers.Grow(ref stash.data, stash.map.capacity);

--- a/Core/StashExtensions.cs
+++ b/Core/StashExtensions.cs
@@ -8,11 +8,47 @@
 namespace Scellecs.Morpeh {
     using System;
     using Collections;
+    using System.Runtime.CompilerServices;
+    
     public static class StashExtensions {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool TryAddData<T>(this Stash<T> stash, in int key, in T value, out int slotIndex) where T : struct, IComponent {
+            if (stash.map.IsKeySet(key, out _)) {
+                slotIndex = -1;
+                return false;
+            }
+
+            slotIndex = stash.map.TakeSlot(in key, out var resized);
+            
+            if (resized) {
+                ArrayHelpers.Grow(ref stash.data, stash.map.capacity);
+            }
+            
+            stash.data[slotIndex] = value;
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool TrySetData<T>(this Stash<T> stash, in int key, in T value) where T : struct, IComponent {
+            if (stash.map.IsKeySet(key, out var slotIndex)) {
+                stash.data[slotIndex] = value;
+                return false;
+            }
+
+            slotIndex = stash.map.TakeSlot(in key, out var resized);
+            
+            if (resized) {
+                ArrayHelpers.Grow(ref stash.data, stash.map.capacity);
+            }
+            
+            stash.data[slotIndex] = value;
+            return true;
+        }
+        
 #if !MORPEH_DISABLE_COMPONENT_DISPOSE
         public static Stash<T> AsDisposable<T>(this Stash<T> stash) where T : struct, IComponent, IDisposable {
 #if MORPEH_DEBUG
-            if (stash == null || stash.components == null) {
+            if (stash == null || stash.IsDisposed) {
                 throw new Exception($"[MORPEH] You are trying mark AsDisposable null or disposed stash");
             }
 #endif
@@ -27,25 +63,5 @@ namespace Scellecs.Morpeh {
             return stash;
         }
 #endif
-
-        public static Stash<T> Clone<T>(this Stash<T> stash) where T : unmanaged, IComponent {
-#if MORPEH_DEBUG
-            if (stash == null || stash.components == null) {
-                throw new Exception($"[MORPEH] You are trying clone null or disposed stash");
-            }
-#endif
-            
-            return new Stash<T>(stash);
-        }
-        
-        public static void CopyFrom<T>(this Stash<T> stash, Stash<T> from) where T : unmanaged, IComponent {
-#if MORPEH_DEBUG
-            if (stash == null || from == null || stash.components == null || from.components == null) {
-                throw new Exception($"[MORPEH] You are trying copy from null or disposed stash");
-            }
-#endif
-            
-            stash.components.CopyFrom(from.components);
-        }
     }
 }

--- a/Core/StashExtensions.cs
+++ b/Core/StashExtensions.cs
@@ -9,9 +9,13 @@ namespace Scellecs.Morpeh {
     using System;
     using Collections;
     using System.Runtime.CompilerServices;
+    using Unity.IL2CPP.CompilerServices;
     
     public static class StashExtensions {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Il2CppSetOption(Option.NullChecks, false)]
+        [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
+        [Il2CppSetOption(Option.DivideByZeroChecks, false)]
         internal static bool TryAddData<T>(this Stash<T> stash, in int key, in T value, out int slotIndex) where T : struct, IComponent {
             if (stash.map.IsKeySet(key, out _)) {
                 slotIndex = -1;
@@ -29,6 +33,9 @@ namespace Scellecs.Morpeh {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Il2CppSetOption(Option.NullChecks, false)]
+        [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
+        [Il2CppSetOption(Option.DivideByZeroChecks, false)]
         internal static bool TrySetData<T>(this Stash<T> stash, in int key, in T value) where T : struct, IComponent {
             if (stash.map.IsKeySet(key, out var slotIndex)) {
                 stash.data[slotIndex] = value;

--- a/Core/StashExtensions.cs
+++ b/Core/StashExtensions.cs
@@ -11,11 +11,11 @@ namespace Scellecs.Morpeh {
     using System.Runtime.CompilerServices;
     using Unity.IL2CPP.CompilerServices;
     
+    [Il2CppSetOption(Option.NullChecks, false)]
+    [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
+    [Il2CppSetOption(Option.DivideByZeroChecks, false)]
     public static class StashExtensions {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [Il2CppSetOption(Option.NullChecks, false)]
-        [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
-        [Il2CppSetOption(Option.DivideByZeroChecks, false)]
         internal static bool TryAddData<T>(this Stash<T> stash, in int key, in T value, out int slotIndex) where T : struct, IComponent {
             if (stash.map.IsKeySet(key, out _)) {
                 slotIndex = -1;
@@ -33,9 +33,6 @@ namespace Scellecs.Morpeh {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [Il2CppSetOption(Option.NullChecks, false)]
-        [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
-        [Il2CppSetOption(Option.DivideByZeroChecks, false)]
         internal static bool TrySetData<T>(this Stash<T> stash, in int key, in T value) where T : struct, IComponent {
             if (stash.map.IsKeySet(key, out var slotIndex)) {
                 stash.data[slotIndex] = value;

--- a/Core/StashMap.cs
+++ b/Core/StashMap.cs
@@ -113,28 +113,6 @@ namespace Scellecs.Morpeh
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void CopyFrom(StashMap from, out bool needResize) {
-            this.lastIndex = from.lastIndex;
-            this.length = from.length;
-            this.freeIndex = from.freeIndex;
-
-            needResize = this.capacity < from.capacity;
-
-            this.capacityMinusOne = from.capacityMinusOne;
-            this.capacity = from.capacity;
-
-            if (needResize) {
-                this.buckets = new IntPinnedArray(this.capacity);
-                this.slots = new PinnedArray<IntHashMapSlot>(this.capacity);
-            }
-
-            for (int i = 0, len = this.capacity; i < len; i++) {
-                this.buckets.data[i] = from.buckets.data[i];
-                this.slots.data[i] = from.slots.data[i];
-            }
-        }
-        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsKeySet(int key, out int slotIndex) {
             var rem = key & this.capacityMinusOne;
 

--- a/Core/StashMap.cs
+++ b/Core/StashMap.cs
@@ -1,15 +1,13 @@
-﻿using System.Runtime.CompilerServices;
-using JetBrains.Annotations;
-using Scellecs.Morpeh.Collections;
-using Unity.IL2CPP.CompilerServices;
-
-namespace Scellecs.Morpeh
-{
+﻿namespace Scellecs.Morpeh {
+    using System.Runtime.CompilerServices;
+    using JetBrains.Annotations;
+    using Scellecs.Morpeh.Collections;
+    using Unity.IL2CPP.CompilerServices;
+    
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public unsafe class StashMap
-    {
+    public unsafe class StashMap {
         internal int length;
         internal int capacity;
         internal int capacityMinusOne;

--- a/Core/StashMap.cs
+++ b/Core/StashMap.cs
@@ -1,0 +1,245 @@
+﻿using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
+using Scellecs.Morpeh.Collections;
+using Unity.IL2CPP.CompilerServices;
+
+namespace Scellecs.Morpeh
+{
+    [Il2CppSetOption(Option.NullChecks, false)]
+    [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
+    [Il2CppSetOption(Option.DivideByZeroChecks, false)]
+    public unsafe class StashMap
+    {
+        public int length;
+        public int capacity;
+        public int capacityMinusOne;
+        public int lastIndex;
+        public int freeIndex;
+        public IntPinnedArray buckets;
+        public PinnedArray<IntHashMapSlot> slots;
+
+        public StashMap(int capacity) {
+            this.lastIndex = 0;
+            this.length = 0;
+            this.freeIndex = -1;
+
+            this.capacityMinusOne = HashHelpers.GetCapacity(capacity - 1);
+            this.capacity = this.capacityMinusOne + 1;
+
+            this.buckets = new IntPinnedArray(this.capacity);
+            this.slots   = new PinnedArray<IntHashMapSlot>(this.capacity);
+        }
+
+        public StashMap(StashMap other) {
+            this.lastIndex = other.lastIndex;
+            this.length    = other.length;
+            this.freeIndex = other.freeIndex;
+
+            this.capacityMinusOne = other.capacityMinusOne;
+            this.capacity         = other.capacity;
+
+            this.buckets = new IntPinnedArray(this.capacity);
+            this.slots   = new PinnedArray<IntHashMapSlot>(this.capacity);
+            
+            for (int i = 0, len = this.capacity; i < len; i++) {
+                this.buckets.data[i] = other.buckets.data[i];
+                this.slots.data[i] = other.slots.data[i];
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetKeyByIndex(in int index) {
+            return slots.ptr[index].key - 1;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Has(in int key) {
+            var rem = key & capacityMinusOne;
+
+            int next;
+            for (var i = buckets.ptr[rem] - 1; i >= 0; i = next) {
+                ref var slot = ref slots.ptr[i];
+                if (slot.key - 1 == key) {
+                    return true;
+                }
+
+                next = slot.next;
+            }
+
+            return false;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Remove(in int key, [CanBeNull] out int dataIndex) {
+            var rem = key & this.capacityMinusOne;
+
+            int next;
+            int num = -1;
+            for (var i = this.buckets.ptr[rem] - 1; i >= 0; i = next) {
+                ref var slot = ref this.slots.ptr[i];
+                if (slot.key - 1 == key) {
+                    if (num < 0) {
+                        this.buckets.ptr[rem] = slot.next + 1;
+                    }
+                    else {
+                        this.slots.ptr[num].next = slot.next;
+                    }
+
+                    dataIndex = i;
+
+                    slot.key  = -1;
+                    slot.next = this.freeIndex;
+
+                    --this.length;
+                    if (this.length == 0) {
+                        this.lastIndex = 0;
+                        this.freeIndex = -1;
+                    }
+                    else {
+                        this.freeIndex = i;
+                    }
+
+                    return true;
+                }
+
+                next = slot.next;
+                num  = i;
+            }
+
+            dataIndex = default;
+            return false;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGetIndex(in int key, out int dataIndex) {
+            var rem = key & this.capacityMinusOne;
+
+            int next;
+            for (var i = this.buckets.ptr[rem] - 1; i >= 0; i = next) {
+                ref var slot = ref this.slots.ptr[i];
+                if (slot.key - 1 == key) {
+                    dataIndex = i;
+                    return true;
+                }
+
+                next = slot.next;
+            }
+
+            dataIndex = default;
+            return false;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void CopyFrom(StashMap from, out bool needResize) {
+            this.lastIndex = from.lastIndex;
+            this.length = from.length;
+            this.freeIndex = from.freeIndex;
+
+            needResize = this.capacity < from.capacity;
+
+            this.capacityMinusOne = from.capacityMinusOne;
+            this.capacity = from.capacity;
+
+            if (needResize) {
+                this.buckets = new IntPinnedArray(this.capacity);
+                this.slots = new PinnedArray<IntHashMapSlot>(this.capacity);
+            }
+
+            for (int i = 0, len = this.capacity; i < len; i++) {
+                this.buckets.data[i] = from.buckets.data[i];
+                this.slots.data[i] = from.slots.data[i];
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsKeySet(in int key, out int slotIndex) {
+            var rem = key & this.capacityMinusOne;
+
+            for (var i = this.buckets.ptr[rem] - 1; i >= 0; i = this.slots.ptr[i].next) {
+                if (this.slots.ptr[i].key - 1 == key) {
+                    slotIndex = i;
+                    return true;
+                }
+            }
+            
+            slotIndex = -1;
+            return false;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsEmpty() {
+            return this.length == 0;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsCapacityFull() {
+            return this.lastIndex == this.capacity;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int TakeSlot(in int key, out bool resized) {
+            resized = false;
+            
+            int slotIndex;
+            if (this.freeIndex >= 0) {
+                slotIndex = this.freeIndex;
+                this.freeIndex = this.slots.ptr[slotIndex].next;
+            }
+            else {
+                if (this.IsCapacityFull()) {
+                    this.Expand();
+                    resized = true;
+                }
+
+                slotIndex = this.lastIndex;
+                ++this.lastIndex;
+            }
+            
+            var rem = key & this.capacityMinusOne;
+            ref var newSlot = ref this.slots.ptr[slotIndex];
+
+            newSlot.key  = key + 1;
+            newSlot.next = this.buckets.ptr[rem] - 1;
+
+            this.buckets.ptr[rem] = slotIndex + 1;
+            ++this.length;
+            
+            return slotIndex;
+        }
+        
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public int Expand() {
+            var newCapacityMinusOne = HashHelpers.GetCapacity(this.length);
+            var newCapacity= newCapacityMinusOne + 1;
+
+            this.slots.Resize(newCapacity);
+
+            var newBuckets = new IntPinnedArray(newCapacity);
+
+            for (int i = 0, len = this.lastIndex; i < len; ++i) {
+                ref var slot = ref this.slots.ptr[i];
+
+                var newResizeIndex = (slot.key - 1) & newCapacityMinusOne;
+                slot.next = newBuckets.ptr[newResizeIndex] - 1;
+
+                newBuckets.ptr[newResizeIndex] = i + 1;
+            }
+
+            this.buckets.Dispose();
+            this.buckets = newBuckets;
+            this.capacity = newCapacity;
+            this.capacityMinusOne = newCapacityMinusOne;
+            
+            return newCapacity;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Clear() {
+            this.slots.Clear();
+            this.buckets.Clear();
+            this.lastIndex = 0;
+            this.length = 0;
+            this.freeIndex = -1;
+        }
+    }
+}

--- a/Core/StashMap.cs
+++ b/Core/StashMap.cs
@@ -31,12 +31,12 @@ namespace Scellecs.Morpeh
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int GetKeyByIndex(in int index) {
+        public int GetKeyByIndex(int index) {
             return slots.ptr[index].key - 1;
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Has(in int key) {
+        public bool Has(int key) {
             var rem = key & capacityMinusOne;
 
             int next;
@@ -53,7 +53,7 @@ namespace Scellecs.Morpeh
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Remove(in int key, [CanBeNull] out int dataIndex) {
+        public bool Remove(int key, [CanBeNull] out int dataIndex) {
             var rem = key & this.capacityMinusOne;
 
             int next;
@@ -94,7 +94,7 @@ namespace Scellecs.Morpeh
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool TryGetIndex(in int key, out int dataIndex) {
+        public bool TryGetIndex(int key, out int dataIndex) {
             var rem = key & this.capacityMinusOne;
 
             int next;
@@ -135,7 +135,7 @@ namespace Scellecs.Morpeh
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool IsKeySet(in int key, out int slotIndex) {
+        public bool IsKeySet(int key, out int slotIndex) {
             var rem = key & this.capacityMinusOne;
 
             for (var i = this.buckets.ptr[rem] - 1; i >= 0; i = this.slots.ptr[i].next) {
@@ -160,7 +160,7 @@ namespace Scellecs.Morpeh
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int TakeSlot(in int key, out bool resized) {
+        public int TakeSlot(int key, out bool resized) {
             resized = false;
             
             int slotIndex;

--- a/Core/StashMap.cs
+++ b/Core/StashMap.cs
@@ -31,8 +31,8 @@ namespace Scellecs.Morpeh
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int GetKeyBySlotIndex(int index) {
-            return slots.ptr[index].key - 1;
+        public int GetKeyBySlotIndex(int slotIndex) {
+            return slots.ptr[slotIndex].key - 1;
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -169,7 +169,7 @@ namespace Scellecs.Morpeh
         }
         
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public int Expand() {
+        private int Expand() {
             var newCapacityMinusOne = HashHelpers.GetCapacity(this.length);
             var newCapacity= newCapacityMinusOne + 1;
 

--- a/Core/StashMap.cs
+++ b/Core/StashMap.cs
@@ -27,7 +27,7 @@ namespace Scellecs.Morpeh
             this.capacity = this.capacityMinusOne + 1;
 
             this.buckets = new IntPinnedArray(this.capacity);
-            this.slots   = new PinnedArray<IntHashMapSlot>(this.capacity);
+            this.slots = new PinnedArray<IntHashMapSlot>(this.capacity);
         }
 
         public StashMap(StashMap other) {
@@ -36,7 +36,7 @@ namespace Scellecs.Morpeh
             this.freeIndex = other.freeIndex;
 
             this.capacityMinusOne = other.capacityMinusOne;
-            this.capacity         = other.capacity;
+            this.capacity = other.capacity;
 
             this.buckets = new IntPinnedArray(this.capacity);
             this.slots = new PinnedArray<IntHashMapSlot>(this.capacity);

--- a/Core/StashMap.cs
+++ b/Core/StashMap.cs
@@ -202,5 +202,44 @@ namespace Scellecs.Morpeh
             this.length = 0;
             this.freeIndex = -1;
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Enumerator GetEnumerator() {
+            Enumerator e;
+            e.map = this;
+            e.index = 0;
+            e.current = default;
+            return e;
+        }
+        
+        [Il2CppSetOption(Option.NullChecks, false)]
+        [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
+        [Il2CppSetOption(Option.DivideByZeroChecks, false)]
+        public struct Enumerator {
+            public StashMap map;
+
+            public int index;
+            public int current;
+
+            public bool MoveNext() {
+                for (; this.index < this.map.lastIndex; ++this.index) {
+                    var slot = this.map.slots.ptr[this.index];
+                    if (slot.key - 1 < 0) {
+                        continue;
+                    }
+
+                    this.current = this.index;
+                    ++this.index;
+
+                    return true;
+                }
+
+                this.index = this.map.lastIndex + 1;
+                this.current = default;
+                return false;
+            }
+
+            public int Current => this.current;
+        }
     }
 }

--- a/Core/StashMap.cs
+++ b/Core/StashMap.cs
@@ -10,13 +10,13 @@ namespace Scellecs.Morpeh
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
     public unsafe class StashMap
     {
-        public int length;
-        public int capacity;
-        public int capacityMinusOne;
-        public int lastIndex;
-        public int freeIndex;
-        public IntPinnedArray buckets;
-        public PinnedArray<IntHashMapSlot> slots;
+        internal int length;
+        internal int capacity;
+        internal int capacityMinusOne;
+        internal int lastIndex;
+        internal int freeIndex;
+        internal IntPinnedArray buckets;
+        internal PinnedArray<IntHashMapSlot> slots;
 
         public StashMap(int capacity) {
             this.lastIndex = 0;

--- a/Core/StashMap.cs
+++ b/Core/StashMap.cs
@@ -99,7 +99,7 @@ namespace Scellecs.Morpeh
 
             int next;
             for (var i = this.buckets.ptr[rem] - 1; i >= 0; i = next) {
-                ref var slot = ref this.slots.ptr[i];
+                var slot = this.slots.ptr[i];
                 if (slot.key - 1 == key) {
                     dataIndex = i;
                     return true;

--- a/Core/StashMap.cs
+++ b/Core/StashMap.cs
@@ -198,7 +198,7 @@ namespace Scellecs.Morpeh
             var rem = key & this.capacityMinusOne;
             ref var newSlot = ref this.slots.ptr[slotIndex];
 
-            newSlot.key  = key + 1;
+            newSlot.key = key + 1;
             newSlot.next = this.buckets.ptr[rem] - 1;
 
             this.buckets.ptr[rem] = slotIndex + 1;

--- a/Core/StashMap.cs
+++ b/Core/StashMap.cs
@@ -29,23 +29,6 @@ namespace Scellecs.Morpeh
             this.buckets = new IntPinnedArray(this.capacity);
             this.slots = new PinnedArray<IntHashMapSlot>(this.capacity);
         }
-
-        public StashMap(StashMap other) {
-            this.lastIndex = other.lastIndex;
-            this.length = other.length;
-            this.freeIndex = other.freeIndex;
-
-            this.capacityMinusOne = other.capacityMinusOne;
-            this.capacity = other.capacity;
-
-            this.buckets = new IntPinnedArray(this.capacity);
-            this.slots = new PinnedArray<IntHashMapSlot>(this.capacity);
-            
-            for (int i = 0, len = this.capacity; i < len; i++) {
-                this.buckets.data[i] = other.buckets.data[i];
-                this.slots.data[i] = other.slots.data[i];
-            }
-        }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetKeyByIndex(in int index) {

--- a/Core/StashMap.cs
+++ b/Core/StashMap.cs
@@ -32,14 +32,14 @@ namespace Scellecs.Morpeh
 
         public StashMap(StashMap other) {
             this.lastIndex = other.lastIndex;
-            this.length    = other.length;
+            this.length = other.length;
             this.freeIndex = other.freeIndex;
 
             this.capacityMinusOne = other.capacityMinusOne;
             this.capacity         = other.capacity;
 
             this.buckets = new IntPinnedArray(this.capacity);
-            this.slots   = new PinnedArray<IntHashMapSlot>(this.capacity);
+            this.slots = new PinnedArray<IntHashMapSlot>(this.capacity);
             
             for (int i = 0, len = this.capacity; i < len; i++) {
                 this.buckets.data[i] = other.buckets.data[i];

--- a/Core/StashMap.cs
+++ b/Core/StashMap.cs
@@ -41,7 +41,7 @@ namespace Scellecs.Morpeh
 
             int next;
             for (var i = buckets.ptr[rem] - 1; i >= 0; i = next) {
-                ref var slot = ref slots.ptr[i];
+                var slot = slots.ptr[i];
                 if (slot.key - 1 == key) {
                     return true;
                 }
@@ -70,7 +70,7 @@ namespace Scellecs.Morpeh
 
                     dataIndex = i;
 
-                    slot.key  = -1;
+                    slot.key = -1;
                     slot.next = this.freeIndex;
 
                     --this.length;

--- a/Core/StashMap.cs
+++ b/Core/StashMap.cs
@@ -31,7 +31,7 @@ namespace Scellecs.Morpeh
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int GetKeyByIndex(int index) {
+        public int GetKeyBySlotIndex(int index) {
             return slots.ptr[index].key - 1;
         }
         
@@ -53,7 +53,7 @@ namespace Scellecs.Morpeh
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Remove(int key, [CanBeNull] out int dataIndex) {
+        public bool Remove(int key, [CanBeNull] out int slotIndex) {
             var rem = key & this.capacityMinusOne;
 
             int next;
@@ -68,7 +68,7 @@ namespace Scellecs.Morpeh
                         this.slots.ptr[num].next = slot.next;
                     }
 
-                    dataIndex = i;
+                    slotIndex = i;
 
                     slot.key = -1;
                     slot.next = this.freeIndex;
@@ -89,26 +89,26 @@ namespace Scellecs.Morpeh
                 num  = i;
             }
 
-            dataIndex = default;
+            slotIndex = default;
             return false;
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool TryGetIndex(int key, out int dataIndex) {
+        public bool TryGetIndex(int key, out int slotIndex) {
             var rem = key & this.capacityMinusOne;
 
             int next;
             for (var i = this.buckets.ptr[rem] - 1; i >= 0; i = next) {
                 var slot = this.slots.ptr[i];
                 if (slot.key - 1 == key) {
-                    dataIndex = i;
+                    slotIndex = i;
                     return true;
                 }
 
                 next = slot.next;
             }
 
-            dataIndex = default;
+            slotIndex = default;
             return false;
         }
         

--- a/Core/StashMap.cs.meta
+++ b/Core/StashMap.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e80f258bf085488d8f404e2336fcbbd4
+timeCreated: 1709730552

--- a/Core/WorldExtensions.cs
+++ b/Core/WorldExtensions.cs
@@ -161,13 +161,13 @@ namespace Scellecs.Morpeh {
             
             var info = TypeIdentifier<T>.info;
             if (world.stashes.TryGetValue(info.id, out var value)) {
-                return value.GetTypedStash<T>();
+                return (Stash<T>)value.typelessStash;
             }
 
             var stash = Stash.Create<T>(world);
             world.stashes.Add(info.id, stash, out _);
 
-            return stash.GetTypedStash<T>();
+            return (Stash<T>)stash.typelessStash;
         }
 
         public static void GlobalUpdate(float deltaTime) {

--- a/Core/WorldExtensions.cs
+++ b/Core/WorldExtensions.cs
@@ -147,11 +147,7 @@ namespace Scellecs.Morpeh {
                 }
             }
 
-            var constructedType = typeof(Stash<>).MakeGenericType(type);
-            var stash           = (Stash)Activator.CreateInstance(constructedType, true);
-
-            stash.world = world;
-
+            var stash = Stash.CreateReflection(world, type);
             CommonTypeIdentifier.typeAssociation.TryGetValue(type, out definition);
             world.stashes.Add(definition.id, stash, out _);
 
@@ -165,15 +161,13 @@ namespace Scellecs.Morpeh {
             
             var info = TypeIdentifier<T>.info;
             if (world.stashes.TryGetValue(info.id, out var value)) {
-                return (Stash<T>)value;
+                return value.GetTypedStash<T>();
             }
 
-            var stash = new Stash<T>();
-            stash.world = world;
-
+            var stash = Stash.Create<T>(world);
             world.stashes.Add(info.id, stash, out _);
 
-            return stash;
+            return stash.GetTypedStash<T>();
         }
 
         public static void GlobalUpdate(float deltaTime) {


### PR DESCRIPTION
Remove all "override" methods from Stash<T> so that all calls to them could be properly inlined in il2cpp. 

Previously, il2cpp generated virtcalls for each method that was overriden: Set, Has, etc, which resulted in performance penalty. Il2cpp doesn't care if we use concrete calls instead of calls through abstract class. This PR should boost performance of many games, especially Commit calls as of their extensive use of Has checks. Performance gains are roughly estimated at 10% for an average project using Stashes directly.

Now stashes are completely separate without any inheritance. Additionally, Stashes can now be iterated over its components directly in case you want to make filterless systems.