### PR TITLE
Morpeh 2024.1 improvements

### DIFF
--- a/Scellecs.Morpeh/Core/Archetypes/Archetype.cs
+++ b/Scellecs.Morpeh/Core/Archetypes/Archetype.cs
@@ -70,7 +70,12 @@ namespace Scellecs.Morpeh {
         public void AddFilter(Filter filter) {
             this.filters.Set(filter.id, filter, out _);
         }
-        
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void RemoveFilter(Filter filter) { 
+            this.filters.Remove(filter.id, out _);
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ClearFilters() {
             this.filters.Clear();

--- a/Scellecs.Morpeh/Core/Components/ComponentId.cs
+++ b/Scellecs.Morpeh/Core/Components/ComponentId.cs
@@ -14,8 +14,8 @@
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void Add(Type type, TypeInfo typeInfo) {
-            typeAssociation.Add(type, typeInfo);
-            idAssociation.Add(typeInfo.id, type);
+            typeAssociation[type] = typeInfo;
+            idAssociation[typeInfo.id] = type;
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -39,7 +39,7 @@
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    internal static class ComponentId<T> where T : struct, IComponent {
+    public static class ComponentId<T> where T : struct, IComponent {
         internal static TypeInfo info;
         internal static bool initialized;
         
@@ -57,8 +57,18 @@
             var typeId = ComponentsCounter.Increment();
             var typeHash = Math.Abs(7_777_777_777_777_777_773L * typeId);
             
-            info = new TypeInfo(new TypeHash(typeHash), typeId);
+            info = new TypeInfo(new TypeHash(typeHash), typeId, StashConstants.DEFAULT_COMPONENTS_CAPACITY);
             
+            ComponentId.Add(typeof(T), info);
+
+#if UNITY_EDITOR || MORPEH_GENERATE_ALL_EXTENDED_IDS
+            ExtendedComponentId.Generate<T>();
+#endif
+        }
+
+        public static void SetStashSize(int size) { 
+            size = size > 0 ? size : StashConstants.DEFAULT_COMPONENTS_CAPACITY;
+            info.stashSize = size;
             ComponentId.Add(typeof(T), info);
 
 #if UNITY_EDITOR || MORPEH_GENERATE_ALL_EXTENDED_IDS

--- a/Scellecs.Morpeh/Core/Components/ComponentsToFiltersRelation.cs
+++ b/Scellecs.Morpeh/Core/Components/ComponentsToFiltersRelation.cs
@@ -2,7 +2,8 @@
     using Unity.IL2CPP.CompilerServices;
     using System.Runtime.CompilerServices;
     using Scellecs.Morpeh.Collections;
-    
+    using System;
+
     [Il2CppSetOption(Option.NullChecks, false)]
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
@@ -34,7 +35,15 @@
                 this.AppendFilter(typeInfo, filter);
             }
         }
-        
+
+        public void Remove(int[] typeIds, Filter filter) {
+            foreach (var typeId in typeIds) {
+                if (typeId < this.componentsToFilters.Length && this.componentsToFilters[typeId] != null) {
+                    this.RemoveFilter(typeId, filter);
+                }
+            }
+        }
+
         private int GetMaxTypeId(int[] typeIds) {
             var maxTypeId = 0;
             foreach (var typeId in typeIds) {
@@ -63,6 +72,20 @@
                 
                 ArrayHelpers.Grow(ref filters, filters.Length + 1);
                 filters[position] = filter;
+            }
+        }
+
+        private void RemoveFilter(int typeId, Filter filter) {
+            ref var filters = ref this.componentsToFilters[typeId];
+            var index = Array.IndexOf(filters, filter);
+            if (index != -1) {
+                var last = filters.Length - 1;
+                if (index < last) {
+                    Array.Copy(filters, index + 1, filters, index, last - index);
+                }
+
+                Array.Resize(ref filters, filters.Length - 1);
+                this.componentsToFilters[typeId] = filters;
             }
         }
     }

--- a/Scellecs.Morpeh/Core/Components/ExtendedComponentId.cs
+++ b/Scellecs.Morpeh/Core/Components/ExtendedComponentId.cs
@@ -55,9 +55,9 @@
                 entityRemoveComponent = (entity) => entity.GetWorld().GetStash<T>().Remove(entity),
                 isMarker = typeof(T).GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Length == 0,
             };
-            
-            typeAssociation.Add(typeof(T), typeDefinition);
-            typeIdAssociation.Add(typeDefinition.typeInfo.id, typeDefinition);
+
+            typeAssociation[typeof(T)] = typeDefinition;
+            typeIdAssociation[typeDefinition.typeInfo.id] = typeDefinition;
             
             return typeDefinition;
         }

--- a/Scellecs.Morpeh/Core/Entities/Entity.cs
+++ b/Scellecs.Morpeh/Core/Entities/Entity.cs
@@ -12,10 +12,10 @@ namespace Scellecs.Morpeh {
     [Il2CppSetOption(Option.DivideByZeroChecks, false)]
     public readonly struct Entity : IEquatable<Entity> {
         internal readonly long value;
-        
-        // [ Id: 32 bits | Generation: 16 bits | WorldId: 8 bits | Unused: 8 bits ]
-        internal Entity(int worldId, int id, ushort generation) {
-            value = ((id & 0xFFFFFFFFL) << 32) | ((generation & 0xFFFFL) << 16) | ((worldId & 0xFFL) << 8);
+
+        // [ Id: 32 bits | Generation: 16 bits | WorldId: 8 bits | WorldGeneration: 8 bits ]
+        internal Entity(int worldId, int worldGeneration, int id, ushort generation) {
+            value = ((id & 0xFFFFFFFFL) << 32) | ((generation & 0xFFFFL) << 16) | ((worldId & 0xFFL) << 8) | (worldGeneration & 0xFFL);
         }
 
         [ShowInInspector]
@@ -35,7 +35,13 @@ namespace Scellecs.Morpeh {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => (int)((value >> 8) & 0xFF);
         }
-        
+
+        [ShowInInspector]
+        public int WorldGeneration {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => (int)(value & 0xFF);
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator ==(Entity lhs, Entity rhs) {
             return lhs.value == rhs.value;
@@ -66,7 +72,7 @@ namespace Scellecs.Morpeh {
         }
 
         public override string ToString() {
-            return $"Entity: Id={this.Id}, Generation={this.Generation}, WorldId={this.WorldId}";
+            return $"Entity: Id={this.Id}, Generation={this.Generation}, WorldId={this.WorldId}, WorldGeneration={this.WorldGeneration}";
         }
     }
 }

--- a/Scellecs.Morpeh/Core/Entities/EntityExtensions.cs
+++ b/Scellecs.Morpeh/Core/Entities/EntityExtensions.cs
@@ -191,8 +191,12 @@ namespace Scellecs.Morpeh {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static World GetWorld(this Entity entity) {
             var worldId = entity.WorldId;
-            
+
             if (worldId < 0 || worldId >= World.worlds.length) {
+                return null;
+            }
+
+            if (entity.WorldGeneration != World.worldsGens[worldId]) {
                 return null;
             }
             

--- a/Scellecs.Morpeh/Core/Filters/Filter.cs
+++ b/Scellecs.Morpeh/Core/Filters/Filter.cs
@@ -76,7 +76,8 @@ namespace Scellecs.Morpeh {
             this.excludedTypeIds = excludedTypeIds;
             this.excludedTypeIdsLookup = new BitSet(excludedTypeIds);
 
-            this.id = world.filterCount++;
+            this.id = this.world.freeFilterIDs.TryPop(out var freeID) ? freeID : this.world.filterCount;
+            this.world.filterCount++;
             
             this.world.componentsFiltersWith.Add(this.includedTypeIds, this);
             this.world.componentsFiltersWithout.Add(this.excludedTypeIds, this);
@@ -88,7 +89,79 @@ namespace Scellecs.Morpeh {
                 }
             }
         }
-        
+
+        [PublicAPI]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose() {
+            this.world.ThreadSafetyCheck();
+            if (this.id >= 0) {
+                if (this.archetypes != null) {
+                    for (int i = 0; i < this.archetypesLength; i++) {
+                        var archetype = this.archetypes[i];
+                        archetype.RemoveFilter(this);
+                    }
+#if MORPEH_BURST
+#if MORPEH_DEBUG
+                    if (this.chunks != null && this.chunks.length > 0) {
+                        MLogger.LogWarning("The filter you're trying to dispose of was used in the Native API. Ensure you dispose of it only after all jobs that used it have completed.");
+                    }
+#endif
+                    this.chunks?.Clear();
+                    this.chunks = null;
+#endif
+                    Array.Clear(this.archetypes, 0, this.archetypes.Length);
+                    this.archetypes = null;
+                    this.archetypesLength = 0;
+                    this.archetypesCapacity = 0;
+                }
+
+                var incHash = default(TypeHash);
+                var excHash = default(TypeHash);
+
+                if (this.includedTypeIds != null) {
+                    for (int i = 0; i < this.includedTypeIds.Length; i++) {
+                        var typeId = this.includedTypeIds[i];
+                        if (ComponentId.TryGet(typeId, out var type)) {
+                            ComponentId.TryGet(type, out var info);
+                            incHash = incHash.Combine(info.hash);
+                        }
+                    }
+                    this.world.componentsFiltersWith.Remove(this.includedTypeIds, this);
+                    Array.Clear(this.includedTypeIds, 0, this.includedTypeIds.Length);
+                    this.includedTypeIds = null;
+                }
+
+                if (this.excludedTypeIds != null) {
+                    for (int i = 0; i < this.excludedTypeIds.Length; i++) {
+                        var typeId = this.excludedTypeIds[i];
+                        if (ComponentId.TryGet(typeId, out var type)) {
+                            ComponentId.TryGet(type, out var info);
+                            excHash = excHash.Combine(info.hash);
+                        }
+                    }
+                    this.world.componentsFiltersWithout.Remove(this.excludedTypeIds, this);
+                    Array.Clear(this.excludedTypeIds, 0, this.excludedTypeIds.Length);
+                    this.excludedTypeIds = null;
+                }
+
+                var lookup = this.world.filtersLookup;
+                if (lookup.TryGetValue(incHash.GetValue(), out var excludeMap)) {
+                    if (excludeMap.TryGetValue(excHash.GetValue(), out _)) {
+                        excludeMap.Remove(excHash.GetValue(), out _);
+                    }
+                }
+
+                this.includedTypeIdsLookup?.Clear();
+                this.includedTypeIdsLookup = null;
+                this.excludedTypeIdsLookup?.Clear();
+                this.excludedTypeIdsLookup = null;
+
+                this.world.freeFilterIDs.Push(this.id);
+                this.world.filterCount--;
+                this.id = -1;
+            }
+        }
+      
         [PublicAPI]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetLengthSlow() {

--- a/Scellecs.Morpeh/Core/Native/NativeWorld.cs
+++ b/Scellecs.Morpeh/Core/Native/NativeWorld.cs
@@ -4,6 +4,7 @@ namespace Scellecs.Morpeh.Native {
 
     public struct NativeWorld {
         public int identifier;
+        public int generation;
         
         [NativeDisableUnsafePtrRestriction]
         public unsafe ushort* entitiesGens;

--- a/Scellecs.Morpeh/Core/Native/NativeWorldExtensions.cs
+++ b/Scellecs.Morpeh/Core/Native/NativeWorldExtensions.cs
@@ -13,6 +13,7 @@ namespace Scellecs.Morpeh.Native {
             fixed (ushort* entitiesGensPtr = world.entitiesGens)
             fixed (int* entitiesCapacityPtr = &world.entitiesCapacity) {
                 nativeWorld.identifier = world.identifier;
+                nativeWorld.generation = world.generation;
                 nativeWorld.entitiesGens = entitiesGensPtr;
                 nativeWorld.entitiesCapacity = entitiesCapacityPtr;
             }

--- a/Scellecs.Morpeh/Core/Stashes/Stash.cs
+++ b/Scellecs.Morpeh/Core/Stashes/Stash.cs
@@ -51,7 +51,7 @@ namespace Scellecs.Morpeh {
             this.world = world;
             this.typeInfo = typeInfo;
             
-            this.map = new StashMap(capacity < 0 ? StashConstants.DEFAULT_COMPONENTS_CAPACITY : capacity);
+            this.map = new StashMap(typeInfo.stashSize);
             this.data = new T[this.map.capacity];
             
             this.empty = default;

--- a/Scellecs.Morpeh/Core/Types/TypeInfo.cs
+++ b/Scellecs.Morpeh/Core/Types/TypeInfo.cs
@@ -7,10 +7,12 @@
     public struct TypeInfo {
         internal TypeHash hash;
         internal int id;
+        internal int stashSize;
         
-        internal TypeInfo(TypeHash hash, int id) {
+        internal TypeInfo(TypeHash hash, int id, int stashSize) {
             this.id = id;
             this.hash = hash;
+            this.stashSize = stashSize;
         }
         
         public override string ToString() {

--- a/Scellecs.Morpeh/Core/Worlds/World.cs
+++ b/Scellecs.Morpeh/Core/Worlds/World.cs
@@ -28,6 +28,9 @@ namespace Scellecs.Morpeh {
         [NotNull]
         [PublicAPI]
         internal static FastList<World> worlds = new FastList<World>().WithElement(null);
+        [NotNull]
+        [PublicAPI]
+        internal static byte[] worldsGens = new byte[4];
 
         internal static int worldsCount = 0;
         
@@ -104,6 +107,9 @@ namespace Scellecs.Morpeh {
         
         [ShowInInspector]
         internal int identifier;
+
+        [ShowInInspector]
+        internal int generation;
         
         [ShowInInspector]
         internal int threadIdLock;
@@ -264,6 +270,10 @@ namespace Scellecs.Morpeh {
 
             worlds.Remove(this);
             worldsCount--;
+
+            unchecked {
+                worldsGens[this.identifier]++;
+            }
             
             this.IsDisposed = true;
         }

--- a/Scellecs.Morpeh/Core/Worlds/World.cs
+++ b/Scellecs.Morpeh/Core/Worlds/World.cs
@@ -28,6 +28,8 @@ namespace Scellecs.Morpeh {
         [NotNull]
         [PublicAPI]
         internal static FastList<World> worlds = new FastList<World>().WithElement(null);
+
+        internal static int worldsCount = 0;
         
         [CanBeNull]
         internal static FastList<IWorldPlugin> plugins;
@@ -119,7 +121,17 @@ namespace Scellecs.Morpeh {
 
         [PublicAPI]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static World Create() => new World().Initialize();
+        public static World Create() {
+            if (worldsCount == WorldConstants.MAX_WORLDS_COUNT) {
+#if MORPEH_DEBUG
+                MLogger.LogError($"Can not create a world, as the number of worlds has reached the limit of {WorldConstants.MAX_WORLDS_COUNT}");
+#endif
+                return null;
+            }
+
+            worldsCount++;
+            return new World().Initialize();
+        }
 
         private World() {
             this.threadIdLock = System.Threading.Thread.CurrentThread.ManagedThreadId;
@@ -251,6 +263,7 @@ namespace Scellecs.Morpeh {
             this.archetypePool = default;
 
             worlds.Remove(this);
+            worldsCount--;
             
             this.IsDisposed = true;
         }

--- a/Scellecs.Morpeh/Core/Worlds/World.cs
+++ b/Scellecs.Morpeh/Core/Worlds/World.cs
@@ -56,6 +56,8 @@ namespace Scellecs.Morpeh {
 #endif
         internal LongHashMap<LongHashMap<Filter>> filtersLookup;
 
+        internal IntStack freeFilterIDs;
+
         //todo custom collection
         [ShowInInspector]
         internal SortedList<int, SystemsGroup> systemsGroups;
@@ -151,6 +153,7 @@ namespace Scellecs.Morpeh {
 
             this.Filter = new FilterBuilder{ world = this };
             this.filtersLookup = new LongHashMap<LongHashMap<Filter>>();
+            this.freeFilterIDs = new IntStack();
         }
 
         [PublicAPI]

--- a/Scellecs.Morpeh/Core/Worlds/World.cs
+++ b/Scellecs.Morpeh/Core/Worlds/World.cs
@@ -24,10 +24,12 @@ namespace Scellecs.Morpeh {
     public sealed partial class World : IDisposable {
         [CanBeNull]
         [PublicAPI]
-        public static World Default => worlds.data[0];
+        public static World Default => defaultWorld;
+        [CanBeNull]
+        internal static World defaultWorld;
         [NotNull]
         [PublicAPI]
-        internal static FastList<World> worlds = new FastList<World>().WithElement(null);
+        internal static FastList<World> worlds = new FastList<World>();
         [NotNull]
         [PublicAPI]
         internal static byte[] worldsGens = new byte[4];
@@ -135,7 +137,6 @@ namespace Scellecs.Morpeh {
                 return null;
             }
 
-            worldsCount++;
             return new World().Initialize();
         }
 
@@ -267,15 +268,10 @@ namespace Scellecs.Morpeh {
             
             this.archetypePool.Dispose();
             this.archetypePool = default;
-
-            worlds.Remove(this);
-            worldsCount--;
-
-            unchecked {
-                worldsGens[this.identifier]++;
-            }
             
             this.IsDisposed = true;
+
+            this.ApplyRemoveWorld();
         }
 
         public struct Metrics {

--- a/Scellecs.Morpeh/Core/Worlds/WorldConstants.cs
+++ b/Scellecs.Morpeh/Core/Worlds/WorldConstants.cs
@@ -1,5 +1,6 @@
 ﻿namespace Scellecs.Morpeh {
     public class WorldConstants {
+        internal const int MAX_WORLDS_COUNT = 256;
         internal const int DEFAULT_ENTITIES_CAPACITY = 256;
         internal const int DEFAULT_STASHES_CAPACITY = 16;
     }

--- a/Scellecs.Morpeh/Core/Worlds/WorldEntityExtensions.cs
+++ b/Scellecs.Morpeh/Core/Worlds/WorldEntityExtensions.cs
@@ -85,7 +85,8 @@
             return entity.Id <= 0 ||
                    entity.Id >= world.entitiesCapacity ||
                    world.entitiesGens[entity.Id] != entity.Generation ||
-                   entity.WorldId != world.identifier;
+                   entity.WorldId != world.identifier ||
+                   entity.WorldGeneration != world.generation;
         }
 
         [PublicAPI]
@@ -96,12 +97,13 @@
             return entity.Id > 0 &&
                    entity.Id < world.entitiesCapacity &&
                    world.entitiesGens[entity.Id] == entity.Generation &&
-                   entity.WorldId == world.identifier;
+                   entity.WorldId == world.identifier &&
+                   entity.WorldGeneration == world.generation;
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static Entity GetEntityAtIndex(this World world, int entityId) {
-            return new Entity(world.identifier, entityId, world.entitiesGens[entityId]);
+            return new Entity(world.identifier, world.generation, entityId, world.entitiesGens[entityId]);
         }
     }
 }

--- a/Scellecs.Morpeh/Core/Worlds/WorldExtensions.cs
+++ b/Scellecs.Morpeh/Core/Worlds/WorldExtensions.cs
@@ -473,7 +473,7 @@ namespace Scellecs.Morpeh {
                 world.entitiesGens[entityId]++;
             }
         }
-        
+
         [PublicAPI]
         public static void WarmupArchetypes(this World world, int count) {
             world.ThreadSafetyCheck();

--- a/Scellecs.Morpeh/Core/Worlds/WorldExtensions.cs
+++ b/Scellecs.Morpeh/Core/Worlds/WorldExtensions.cs
@@ -100,7 +100,9 @@ namespace Scellecs.Morpeh {
 #endif
         [PublicAPI]
         public static void InitializationDefaultWorld() {
-            foreach (var world in World.worlds) {
+            var worlds = World.worlds.data;
+            for (int i = World.worlds.length - 1; i >= 0; i--) {
+                var world = worlds[i];
                 if (!world.IsNullOrDisposed()) {
                     world.Dispose();
                 }

--- a/Scellecs.Morpeh/Core/Worlds/WorldExtensions.cs
+++ b/Scellecs.Morpeh/Core/Worlds/WorldExtensions.cs
@@ -96,6 +96,8 @@ namespace Scellecs.Morpeh {
                     world.Dispose();
                 }
             }
+
+            World.worldsCount = 0;
             World.worlds.Clear();
             var defaultWorld = World.Create();
             defaultWorld.UpdateByUnity = true;

--- a/Scellecs.Morpeh/Core/Worlds/WorldExtensions.cs
+++ b/Scellecs.Morpeh/Core/Worlds/WorldExtensions.cs
@@ -28,23 +28,7 @@ namespace Scellecs.Morpeh {
     public static class WorldExtensions {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static World Initialize(this World world) {
-            var added = false;
-            var id    = -1;
-
-            for (int i = 0, length = World.worlds.length; i < length; i++) {
-                if (World.worlds.data[i] == null) {
-                    added                = true;
-                    id                   = i;
-                    World.worlds.data[i] = world;
-                    break;
-                }
-            }
-
-            if (added == false) {
-                World.worlds.Add(world);
-                id = World.worlds.length - 1;
-            }
-
+            var id = World.worlds.length;
             if (id >= World.worldsGens.Length) {
                 var newCapacity = HashHelpers.GetCapacity(id) + 1;
                 ArrayHelpers.Grow(ref World.worldsGens, newCapacity);
@@ -92,7 +76,23 @@ namespace Scellecs.Morpeh {
                 }
             }
 
+            world.ApplyAddWorld();
             return world;
+        }
+
+        internal static void ApplyAddWorld(this World world) {
+            World.worlds.Add(world);
+            World.worldsCount++;
+            World.defaultWorld = World.worlds.data[0];
+        }
+
+        internal static void ApplyRemoveWorld(this World world) {
+            unchecked {
+                World.worldsGens[world.identifier]++;
+            }
+            World.worlds.Remove(world);
+            World.worldsCount--;
+            World.defaultWorld = World.worldsCount > 0 ? World.worlds.data[0] : null;
         }
 
 #if MORPEH_UNITY && !MORPEH_DISABLE_AUTOINITIALIZATION

--- a/Scellecs.Morpeh/Core/Worlds/WorldExtensions.cs
+++ b/Scellecs.Morpeh/Core/Worlds/WorldExtensions.cs
@@ -39,10 +39,19 @@ namespace Scellecs.Morpeh {
                     break;
                 }
             }
+
             if (added == false) {
                 World.worlds.Add(world);
+                id = World.worlds.length - 1;
             }
-            world.identifier        = added ? id : World.worlds.length - 1;
+
+            if (id >= World.worldsGens.Length) {
+                var newCapacity = HashHelpers.GetCapacity(id) + 1;
+                ArrayHelpers.Grow(ref World.worldsGens, newCapacity);
+            }
+
+            world.identifier        = id;
+            world.generation        = World.worldsGens[id];
             world.freeEntityIDs     = new IntStack();
             world.stashes           = new IStash[WorldConstants.DEFAULT_STASHES_CAPACITY];
 

--- a/Scellecs.Morpeh/Unity/Providers/WorldViewer.cs
+++ b/Scellecs.Morpeh/Unity/Providers/WorldViewer.cs
@@ -40,7 +40,7 @@ namespace Scellecs.Morpeh.Providers {
                             ref var entityData = ref w.entities[i];
                             
                             if (entityData.currentArchetype != null) {
-                                var entity = new Entity(w.identifier, i, w.entitiesGens[i]);
+                                var entity = new Entity(w.identifier, w.generation, i, w.entitiesGens[i]);
                                 var view = new EntityView {Name = entity.ToString(), entityViewer = {getter = () => entity}};
                                 this.entityViews.Add(view);
                             }

--- a/Scellecs.Morpeh/Unity/UnityRuntimeHelper.cs
+++ b/Scellecs.Morpeh/Unity/UnityRuntimeHelper.cs
@@ -55,9 +55,7 @@ namespace Scellecs.Morpeh {
                 }
 
                 World.worldsCount = 0;
-                World.worlds.Clear();
-                World.worlds.Add(null);
-                
+                World.worlds.Clear();                
                 World.plugins?.Clear();
 
                 if (this != null && this.gameObject != null) {

--- a/Scellecs.Morpeh/Unity/UnityRuntimeHelper.cs
+++ b/Scellecs.Morpeh/Unity/UnityRuntimeHelper.cs
@@ -35,7 +35,7 @@ namespace Scellecs.Morpeh {
 #endif
             }
             else {
-                Destroy(this);
+                Destroy(this.gameObject);
             }
         }
 

--- a/Scellecs.Morpeh/Unity/UnityRuntimeHelper.cs
+++ b/Scellecs.Morpeh/Unity/UnityRuntimeHelper.cs
@@ -54,6 +54,7 @@ namespace Scellecs.Morpeh {
                     world?.Dispose();
                 }
 
+                World.worldsCount = 0;
                 World.worlds.Clear();
                 World.worlds.Add(null);
                 

--- a/Tests~/FilterDisposalTests.cs
+++ b/Tests~/FilterDisposalTests.cs
@@ -1,0 +1,541 @@
+﻿using Scellecs.Morpeh;
+using Scellecs.Morpeh.Collections;
+using Xunit.Abstractions;
+
+namespace Tests;
+
+[Collection("Sequential")]
+public class FilterDisposalTests {
+    private readonly ITestOutputHelper output;
+    private readonly World world;
+
+    public FilterDisposalTests(ITestOutputHelper output) {
+        this.output = output;
+        MLogger.SetInstance(new XUnitLogger(this.output));
+
+        this.world = World.Create();
+    }
+
+    [Fact]
+    public void DisposeInvalidatesFilter() {
+        var ent = this.world.CreateEntity(); 
+        ent.AddComponent<Test1>();
+        this.world.Commit();
+
+        var filter = this.world.Filter.With<Test1>().Build();
+        foreach (var filterEnt in filter) {
+            Assert.Equal(ent, filterEnt);
+        }
+
+        filter.Dispose();
+        foreach (var _ in filter) {
+            Assert.Fail("Filter should be invalid after Dispose");
+        }
+        Assert.Equal(-1, filter.id);
+    }
+
+    [Fact]
+    public void DisposeCalledTwiceDoesNotThrow() { 
+        var filter = this.world.Filter.With<Test1>().Build();
+        filter.Dispose();
+        filter.Dispose();
+    }
+
+    [Fact]
+    public void DisposeInvalidatesAllFilterReferences() {
+        var ent = this.world.CreateEntity();
+        ent.AddComponent<Test1>();
+        this.world.Commit();
+
+        var filter0 = this.world.Filter.With<Test1>().Build();
+        var filter1 = this.world.Filter.With<Test1>().Build();
+        foreach (var filterEnt in filter0) {
+            Assert.Equal(ent, filterEnt);
+        }
+
+        filter0.Dispose();
+        foreach (var _ in filter0) {
+            Assert.Fail("Filter0 should be invalid after Dispose");
+        }
+        foreach (var _ in filter1) {
+            Assert.Fail("Filter1 should be invalid after Dispose");
+        }
+        Assert.Equal(-1, filter0.id);
+        Assert.Equal(-1, filter1.id);
+    }
+
+    [Fact]
+    public void DisposeRemovesFilterFromWorld() {
+        var ent = this.world.CreateEntity();
+        ent.AddComponent<Test1>();
+        this.world.Commit();
+
+        var filterBuilder = this.world.Filter.With<Test1>();
+        var incHash = filterBuilder.includeHash;
+        var excHash = filterBuilder.excludeHash;
+        var filter = filterBuilder.Build();
+        var filterId = filter.id;
+        foreach (var filterEnt in filter) {
+            Assert.Equal(ent, filterEnt);
+        }
+
+        this.world.Commit();
+
+        var filterArchetype = filter.archetypes[0];
+        var entArchetype = world.entities[ent.Id].currentArchetype;
+        Assert.NotNull(filterArchetype);
+        Assert.NotNull(entArchetype);
+        Assert.Equal(filterArchetype.hash, entArchetype.hash);
+
+        var typeId = ComponentId<Test1>.info.id;
+
+        {
+            var filtersWith = world.componentsFiltersWith.GetFilters(typeId);
+            Assert.Single(filtersWith);
+            Assert.Contains(filter, filtersWith);
+            Assert.Equal(filtersWith[0], filter);
+
+            var lookup = this.world.filtersLookup;
+            if (lookup.TryGetValue(incHash.GetValue(), out var excludeMap)) {
+                if (excludeMap.TryGetValue(excHash.GetValue(), out var lfilter)) {
+                    Assert.Equal(filter, lfilter);
+                }
+            }
+        }
+
+        filter.Dispose();
+
+        {
+            var filtersWith = world.componentsFiltersWith.GetFilters(typeId);
+            Assert.Empty(filtersWith);
+            Assert.Null(filter.archetypes);
+            var lookup = this.world.filtersLookup;
+            if (lookup.TryGetValue(incHash.GetValue(), out var excludeMap)) {
+                if (excludeMap.TryGetValue(excHash.GetValue(), out _)) {
+                    Assert.Fail("Filter should be deleted from lookup");
+                }
+            }
+            Assert.Equal(0, world.filterCount);
+            Assert.Equal(1, world.freeFilterIDs.length);
+            Assert.Equal(-1, filter.id);
+
+            var freeId = world.freeFilterIDs.Pop();
+            Assert.Equal(filterId, freeId);
+            Assert.NotEqual(filter.id, freeId);
+        }
+    }
+
+    [Fact]
+    public void DisposeFreesIdAndAssignsItToNewFilter() {
+        var ent = this.world.CreateEntity();
+        ent.AddComponent<Test1>();
+        ent.AddComponent<Test2>();
+        this.world.Commit();
+
+        var filterBuilder0 = this.world.Filter.With<Test1>();
+        var filter0 = filterBuilder0.Build();
+        var filterId0 = filter0.id;
+
+        var filterBuilder1 = this.world.Filter.With<Test1>().With<Test2>();
+        var filter1 = filterBuilder1.Build();
+        var filterId1 = filter1.id;
+
+        var filterBuilder2 = this.world.Filter.With<Test2>();
+        var filter2 = filterBuilder2.Build();
+        var filterId2 = filter2.id;
+
+        Assert.NotEqual(filterId0, filterId1);
+        Assert.NotEqual(filterId0, filterId2);
+        Assert.NotEqual(filterId1, filterId2);
+
+        this.world.Commit();
+
+        filter1.Dispose();
+
+        Assert.Equal(1, world.freeFilterIDs.length);
+
+        var filterBuilder3 = this.world.Filter.With<Test1>().Without<Test4>();
+        var filter3 = filterBuilder3.Build();
+        var filterId3 = filter3.id;
+
+        Assert.Equal(0, world.freeFilterIDs.length);
+        Assert.Equal(filterId1, filterId3);
+
+        Assert.Equal(filterId0, filter0.id);
+        Assert.Equal(filterId2, filter2.id);
+
+        foreach (var filterEnt in filter0) {
+            Assert.Equal(ent, filterEnt);
+        }
+
+        foreach (var filterEnt in filter2) {
+            Assert.Equal(ent, filterEnt);
+        }
+
+        foreach (var filterEnt in filter3) {
+            Assert.Equal(ent, filterEnt);
+        }
+    }
+
+    [Fact]
+    public void DisposeRemovesMatchingFilterAndKeepsOtherValid() {
+        var ent = this.world.CreateEntity();
+        ent.AddComponent<Test1>();
+        this.world.Commit();
+
+        var filterBuilder0 = this.world.Filter.With<Test1>();
+        var incHash0 = filterBuilder0.includeHash;
+        var excHash0 = filterBuilder0.excludeHash;
+        var filter0 = filterBuilder0.Build();
+        var filterId0 = filter0.id;
+
+        var filterBuilder1 = this.world.Filter.With<Test1>().Without<Test2>();
+        var incHash1 = filterBuilder1.includeHash;
+        var excHash1 = filterBuilder1.excludeHash;
+        var filter1 = filterBuilder1.Build();
+
+        foreach (var filterEnt in filter0) {
+            Assert.Equal(ent, filterEnt);
+        }
+        foreach (var filterEnt in filter1) {
+            Assert.Equal(ent, filterEnt);
+        }
+
+        this.world.Commit();
+
+        var typeIdWith = ComponentId<Test1>.info.id;
+        var typeIdWithout = ComponentId<Test2>.info.id;
+
+        {
+            var filtersWith = world.componentsFiltersWith.GetFilters(typeIdWith);
+            Assert.Contains(filter0, filtersWith);
+            Assert.Contains(filter1, filtersWith);
+
+            var filtersWithout = world.componentsFiltersWithout.GetFilters(typeIdWithout);
+            Assert.Single(filtersWithout);
+            Assert.Contains(filter1, filtersWithout);
+            Assert.Equal(filtersWithout[0], filter1);
+
+            var lookup = this.world.filtersLookup;
+            if (lookup.TryGetValue(incHash0.GetValue(), out var excludeMap0)) {
+                Assert.True(excludeMap0.TryGetValue(excHash0.GetValue(), out var lfilter0));
+                Assert.Equal(filter0, lfilter0);
+            }
+
+            if (lookup.TryGetValue(incHash1.GetValue(), out var excludeMap1)) {
+                Assert.True(excludeMap1.TryGetValue(excHash1.GetValue(), out var lfilter1));
+                Assert.Equal(filter1, lfilter1);
+            }
+        }
+
+        filter0.Dispose();
+
+        {
+            var filtersWith = world.componentsFiltersWith.GetFilters(typeIdWith);
+            Assert.Single(filtersWith);
+            Assert.DoesNotContain(filter0, filtersWith);
+            Assert.Contains(filter1, filtersWith);
+
+            var filtersWithout = world.componentsFiltersWithout.GetFilters(typeIdWithout);
+            Assert.Single(filtersWithout);
+            Assert.Contains(filter1, filtersWithout);
+            Assert.Equal(filtersWithout[0], filter1);
+
+            var lookup = this.world.filtersLookup;
+            if (lookup.TryGetValue(incHash0.GetValue(), out var excludeMap0)) {
+                Assert.False(excludeMap0.TryGetValue(excHash0.GetValue(), out _));
+            }
+
+            if (lookup.TryGetValue(incHash1.GetValue(), out var excludeMap1)) {
+                Assert.True(excludeMap1.TryGetValue(excHash1.GetValue(), out var lfilter1));
+                Assert.Equal(filter1, lfilter1);
+            }
+
+            Assert.Equal(1, world.filterCount);
+            Assert.Equal(1, world.freeFilterIDs.length);
+            Assert.Equal(-1, filter0.id);
+
+            var freeId = world.freeFilterIDs.Pop();
+            Assert.Equal(filterId0, freeId);
+            Assert.NotEqual(filter0.id, freeId);
+        }
+
+        foreach (var filterEnt in filter1) {
+            Assert.Equal(ent, filterEnt);
+        }
+    }
+
+    [Fact]
+    public void DisposeRemovesMatchingFilterAndKeepsOtherValid2()
+    {
+        var ent = this.world.CreateEntity();
+        ent.AddComponent<Test1>();
+        ent.AddComponent<Test2>();
+        this.world.Commit();
+
+        var filterBuilder0 = this.world.Filter.With<Test1>();
+        var incHash0 = filterBuilder0.includeHash;
+        var excHash0 = filterBuilder0.excludeHash;
+        var filter0 = filterBuilder0.Build();
+        var filterId0 = filter0.id;
+
+        var filterBuilder1 = this.world.Filter.With<Test1>().With<Test2>();
+        var incHash1 = filterBuilder1.includeHash;
+        var excHash1 = filterBuilder1.excludeHash;
+        var filter1 = filterBuilder1.Build();
+
+        foreach (var filterEnt in filter0) {
+            Assert.Equal(ent, filterEnt);
+        }
+        foreach (var filterEnt in filter1) {
+            Assert.Equal(ent, filterEnt);
+        }
+
+        this.world.Commit();
+
+        var typeIdWith1 = ComponentId<Test1>.info.id;
+        var typeIdWith2 = ComponentId<Test2>.info.id;
+
+        {
+            var filtersWith1 = world.componentsFiltersWith.GetFilters(typeIdWith1);
+            Assert.Contains(filter0, filtersWith1);
+            Assert.Contains(filter1, filtersWith1);
+
+            var filtersWith2 = world.componentsFiltersWith.GetFilters(typeIdWith2);
+            Assert.Single(filtersWith2);
+            Assert.Contains(filter1, filtersWith2);
+            Assert.Equal(filtersWith2[0], filter1);
+
+            var lookup = this.world.filtersLookup;
+            if (lookup.TryGetValue(incHash0.GetValue(), out var excludeMap0)) {
+                Assert.True(excludeMap0.TryGetValue(excHash0.GetValue(), out var lfilter0));
+                Assert.Equal(filter0, lfilter0);
+            }
+
+            if (lookup.TryGetValue(incHash1.GetValue(), out var excludeMap1)) {
+                Assert.True(excludeMap1.TryGetValue(excHash1.GetValue(), out var lfilter1));
+                Assert.Equal(filter1, lfilter1);
+            }
+        }
+
+        filter0.Dispose();
+
+        {
+            var filtersWith1 = world.componentsFiltersWith.GetFilters(typeIdWith1);
+            Assert.Single(filtersWith1);
+            Assert.DoesNotContain(filter0, filtersWith1);
+            Assert.Contains(filter1, filtersWith1);
+
+            var filtersWith2 = world.componentsFiltersWith.GetFilters(typeIdWith2);
+            Assert.Single(filtersWith2);
+            Assert.Contains(filter1, filtersWith2);
+            Assert.Equal(filtersWith2[0], filter1);
+
+            var lookup = this.world.filtersLookup;
+            if (lookup.TryGetValue(incHash0.GetValue(), out var excludeMap0)) {
+                Assert.False(excludeMap0.TryGetValue(excHash0.GetValue(), out _));
+            }
+
+            if (lookup.TryGetValue(incHash1.GetValue(), out var excludeMap1)) {
+                Assert.True(excludeMap1.TryGetValue(excHash1.GetValue(), out var lfilter1));
+                Assert.Equal(filter1, lfilter1);
+            }
+
+            Assert.Equal(1, world.filterCount);
+            Assert.Equal(1, world.freeFilterIDs.length);
+            Assert.Equal(-1, filter0.id);
+
+            var freeId = world.freeFilterIDs.Pop();
+            Assert.Equal(filterId0, freeId);
+            Assert.NotEqual(filter0.id, freeId);
+        }
+
+        foreach (var filterEnt in filter1) { 
+            Assert.Equal(ent, filterEnt);
+        }
+    }
+
+    [Fact]
+    public void StructuralChangesFilter() {
+        var ent = this.world.CreateEntity();
+        ent.AddComponent<Test1>();
+        ent.AddComponent<Test2>();
+
+        this.world.Commit();
+
+        var filterBuilder = this.world.Filter.With<Test1>().With<Test3>();
+        var filter = filterBuilder.Build();
+
+        foreach (var _ in filter) {
+            Assert.Fail("Filter should be empty");
+        }
+
+        this.world.Commit();
+
+        ent.AddComponent<Test3>();
+
+        foreach (var _ in filter) {
+            Assert.Fail("Filter should be empty");
+        }
+
+        this.world.Commit();
+
+        foreach (var filterEnt in filter) {
+            Assert.Equal(ent, filterEnt);
+        }
+
+        Assert.NotNull(filter.archetypes);
+        Assert.Equal(1, this.world.filterCount);
+        Assert.Equal(0, this.world.freeFilterIDs.length);
+    }
+
+    [Fact]
+    public void StructuralChangesDoNotThrow() {
+        var ent = this.world.CreateEntity();
+        ent.AddComponent<Test1>();
+        ent.AddComponent<Test2>();
+
+        this.world.Commit();
+
+        var filterBuilder = this.world.Filter.With<Test1>().With<Test3>();
+        var filter = filterBuilder.Build();
+
+        foreach (var _ in filter) {
+            Assert.Fail("Filter should be empty");
+        }
+
+        this.world.Commit();
+
+        ent.AddComponent<Test3>();
+
+        foreach (var _ in filter) {
+            Assert.Fail("Filter should be empty");
+        }
+
+        filter.Dispose();
+        this.world.Commit();
+
+        Assert.Null(filter.archetypes);
+        Assert.Equal(0, this.world.filterCount);
+        Assert.Equal(1, this.world.freeFilterIDs.length);
+        Assert.Equal(-1, filter.id);
+    }
+
+    [Fact]
+    public void StructuralChangesWithMultipleMatchesFilters() {
+        var ent = this.world.CreateEntity();
+        ent.AddComponent<Test1>();
+        ent.AddComponent<Test2>();
+        ent.AddComponent<Test3>();
+        this.world.Commit();
+
+        var filterBuilder0 = this.world.Filter.With<Test1>().With<Test2>();
+        var filter0 = filterBuilder0.Build();
+
+        var filterBuilder1 = this.world.Filter.With<Test1>().With<Test3>();
+        var filter1 = filterBuilder1.Build();
+
+        var filterBuilder2 = this.world.Filter.With<Test2>().With<Test3>();
+        var filter2 = filterBuilder2.Build();
+
+        foreach (var filterEnt in filter0) {
+            Assert.Equal(ent, filterEnt);
+        }
+        foreach (var filterEnt in filter1) {
+            Assert.Equal(ent, filterEnt);
+        }
+        foreach (var filterEnt in filter2) {
+            Assert.Equal(ent, filterEnt);
+        }
+
+        ent.AddComponent<Test4>();
+
+        this.world.Commit();
+
+        foreach (var filterEnt in filter0) {
+            Assert.Equal(ent, filterEnt);
+        }
+        foreach (var filterEnt in filter1) {
+            Assert.Equal(ent, filterEnt);
+        }
+        foreach (var filterEnt in filter2) {
+            Assert.Equal(ent, filterEnt);
+        }
+
+        ent.RemoveComponent<Test2>();
+        this.world.Commit();
+
+        foreach (var _ in filter0) {
+            Assert.Fail("Filter0 should be empty");
+        }
+        foreach (var filterEnt in filter1) {
+            Assert.Equal(ent, filterEnt);
+        }
+        foreach (var _ in filter2) {
+            Assert.Fail("Filter2 should be empty");
+        }
+
+        ent.AddComponent<Test2>();
+        filter1.Dispose();
+
+        foreach (var _ in filter0) {
+            Assert.Fail("Filter0 should be empty");
+        }
+        foreach (var _ in filter1) {
+            Assert.Fail("Filter1 should be invalid after Dispose");
+        }
+        foreach (var _ in filter2) {
+            Assert.Fail("Filter2 should be empty");
+        }
+
+        this.world.Commit();
+
+        foreach (var filterEnt in filter0) {
+            Assert.Equal(ent, filterEnt);
+        }
+        foreach (var _ in filter1) {
+            Assert.Fail("Filter1 should be invalid after Dispose");
+        }
+        foreach (var filterEnt in filter2) {
+            Assert.Equal(ent, filterEnt);
+        }
+
+        var typeIdWith0 = ComponentId<Test1>.info.id;
+        var typeIdWith1 = ComponentId<Test2>.info.id;
+        var typeIdWith2 = ComponentId<Test3>.info.id;
+
+        var filtersWith0 = world.componentsFiltersWith.GetFilters(typeIdWith0);
+        Assert.Single(filtersWith0);
+        Assert.Contains(filter0, filtersWith0);
+
+        var filtersWith1 = world.componentsFiltersWith.GetFilters(typeIdWith1);
+        Assert.Equal(2, filtersWith1.Length);
+        Assert.Contains(filter0, filtersWith1);
+        Assert.Contains(filter2, filtersWith1);
+
+        var filtersWith2 = world.componentsFiltersWith.GetFilters(typeIdWith2);
+        Assert.Single(filtersWith2);
+        Assert.Contains(filter2, filtersWith1);
+
+        Assert.DoesNotContain(filter1, filtersWith0);
+        Assert.DoesNotContain(filter1, filtersWith2);
+
+        var lookup = this.world.filtersLookup;
+        if (lookup.TryGetValue(filterBuilder0.includeHash.GetValue(), out var excludeMap0)) {
+            Assert.True(excludeMap0.TryGetValue(filterBuilder0.excludeHash.GetValue(), out var lfilter0));
+            Assert.Equal(filter0, lfilter0);
+        }
+
+        if (lookup.TryGetValue(filterBuilder1.includeHash.GetValue(), out var excludeMap1)) {
+            Assert.False(excludeMap1.TryGetValue(filterBuilder1.excludeHash.GetValue(), out _)); 
+        }
+
+        if (lookup.TryGetValue(filterBuilder2.includeHash.GetValue(), out var excludeMap2)) {
+            Assert.True(excludeMap2.TryGetValue(filterBuilder2.excludeHash.GetValue(), out var lfilter2));
+            Assert.Equal(filter2, lfilter2);
+        }
+
+        Assert.Equal(2, world.filterCount);
+        Assert.Equal(1, world.freeFilterIDs.length);
+    }
+}


### PR DESCRIPTION
### Added
- Limit on the maximum number of worlds to 256.
- The default world is now stored in a separate field instead of being directly taken from the array. However, the first element of the ``worlds`` array is still the default world.
- Introduced generations for worlds, also up to 256.
- Added an optional ``Filter.Dispose`` method.
- Added ``SetStashSize`` method in ``ComponentId<T>``. The ``ComponentId<T>`` class is now publicly accessible.

### Removed
- Removed the addition of a null element to the ``worlds`` array and all related checks.

### Fixed
- When creating multiple ``UnityRuntimeHelper`` instances, only the ``MonoBehaviour`` was being removed. Now, the entire ``GameObject`` is destroyed.
- Fixed iteration with deletion using ``foreach`` in ``WorldExtensions.InitializationDefaultWorld``, where only half of the worlds were being disposed. This has been replaced with a reverse ``for`` loop.