### PR TITLE
Rework of FastList<T>

### DIFF
--- a/Scellecs.Morpeh/Core/Archetypes/ArchetypePool.cs
+++ b/Scellecs.Morpeh/Core/Archetypes/ArchetypePool.cs
@@ -29,7 +29,7 @@
             var index = this.archetypes.length - 1;
             
             var archetype = this.archetypes.data[index];
-            this.archetypes.RemoveAt(index);
+            this.archetypes.RemoveAtFast(index);
             
             archetype.hash = archetypeHash;
             

--- a/Scellecs.Morpeh/Core/Collections/FastList.cs
+++ b/Scellecs.Morpeh/Core/Collections/FastList.cs
@@ -1,6 +1,5 @@
 namespace Scellecs.Morpeh.Collections {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Runtime.CompilerServices;
     using Unity.IL2CPP.CompilerServices;
@@ -15,6 +14,30 @@ namespace Scellecs.Morpeh.Collections {
         public int capacity;
 
         public EqualityComparer<T> comparer;
+
+        /// <summary>
+        /// Gets the element at the specified index in the list.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the index is out of range.</exception>
+        /// <remarks>To avoid bounds checking, use <c>data[index]</c> directly.</remarks>
+        public T this[int index] {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get {
+                if (index < 0 || index >= this.length) {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                return data[index];
+            }
+
+            set {
+                if (index < 0 || index >= this.length) {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                this.data[index] = value;
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public FastList() {
@@ -73,13 +96,5 @@ namespace Scellecs.Morpeh.Collections {
                 get => this.data[this.index];
             }
         }
-    }
-    
-    [Il2CppSetOption(Option.NullChecks, false)]
-    [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
-    [Il2CppSetOption(Option.DivideByZeroChecks, false)]
-    public struct ResultSwap {
-        public int oldIndex;
-        public int newIndex;
     }
 }

--- a/Scellecs.Morpeh/Core/Collections/FastList.cs
+++ b/Scellecs.Morpeh/Core/Collections/FastList.cs
@@ -30,6 +30,7 @@ namespace Scellecs.Morpeh.Collections {
                 return data[index];
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set {
                 if (index < 0 || index >= this.length) {
                     throw new ArgumentOutOfRangeException(nameof(index));

--- a/Scellecs.Morpeh/Core/Collections/FastList.cs
+++ b/Scellecs.Morpeh/Core/Collections/FastList.cs
@@ -24,7 +24,7 @@ namespace Scellecs.Morpeh.Collections {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get {
                 if (index < 0 || index >= this.length) {
-                    throw new ArgumentOutOfRangeException(nameof(index));
+                    SystemExceptionUtility.ThrowArgumentOutOfRangeException(nameof(index));
                 }
 
                 return data[index];
@@ -33,7 +33,7 @@ namespace Scellecs.Morpeh.Collections {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set {
                 if (index < 0 || index >= this.length) {
-                    throw new ArgumentOutOfRangeException(nameof(index));
+                    SystemExceptionUtility.ThrowArgumentOutOfRangeException(nameof(index));
                 }
 
                 this.data[index] = value;

--- a/Scellecs.Morpeh/Core/Collections/FastListExtensions.cs
+++ b/Scellecs.Morpeh/Core/Collections/FastListExtensions.cs
@@ -117,7 +117,7 @@ namespace Scellecs.Morpeh.Collections {
             var index = list.IndexOf(value);
             var shouldRemove = index >= 0;
             if (shouldRemove) {
-                list.RemoveAtSwapBack(index);
+                list.RemoveAtSwapBackFast(index);
             }
 
             return shouldRemove;
@@ -133,6 +133,18 @@ namespace Scellecs.Morpeh.Collections {
                 SystemExceptionUtility.ThrowArgumentOutOfRangeException(nameof(index));
             }
 
+            var lastIndex = list.length - 1;
+            list.data[index] = list.data[lastIndex];
+            list.data[lastIndex] = default;
+            list.length--;
+        }
+
+        /// <summary>
+        /// Removes the element at the specified index by overwriting it with the last element in the list, and decrements the size of the list.
+        /// Does not perform bounds checking.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RemoveAtSwapBackFast<T>(this FastList<T> list, int index) {
             var lastIndex = list.length - 1;
             list.data[index] = list.data[lastIndex];
             list.data[lastIndex] = default;

--- a/Scellecs.Morpeh/Core/Collections/FastListExtensions.cs
+++ b/Scellecs.Morpeh/Core/Collections/FastListExtensions.cs
@@ -88,7 +88,7 @@ namespace Scellecs.Morpeh.Collections {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void RemoveAt<T>(this FastList<T> list, int index) {
             if (index < 0 || index >= list.length) {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                SystemExceptionUtility.ThrowArgumentOutOfRangeException(nameof(index));
             }
 
             --list.length;
@@ -130,7 +130,7 @@ namespace Scellecs.Morpeh.Collections {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void RemoveAtSwapBack<T>(this FastList<T> list, int index) {
             if (index < 0 || index >= list.length) {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                SystemExceptionUtility.ThrowArgumentOutOfRangeException(nameof(index));
             }
 
             var lastIndex = list.length - 1;
@@ -153,16 +153,16 @@ namespace Scellecs.Morpeh.Collections {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void RemoveRange<T>(this FastList<T> list, int index, int count) {
             if (index < 0 || index >= list.length) {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                SystemExceptionUtility.ThrowArgumentOutOfRangeException(nameof(index));
             }
 
             if (count < 0) {
-                throw new ArgumentOutOfRangeException(nameof(count), "Non-negative number required");
+                SystemExceptionUtility.ThrowArgumentOutOfRangeException(nameof(count), "Non-negative number required");
             }
 
             var elementsToMove = list.length - (index + count);
             if (elementsToMove < 0) {
-                throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.", nameof(count));
+                SystemExceptionUtility.ThrowArgumentException(nameof(count), "Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
             }
 
             if (elementsToMove > 0) {
@@ -248,15 +248,15 @@ namespace Scellecs.Morpeh.Collections {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Sort<T>(this FastList<T> list, int index, int count, IComparer<T> comparer = null) {
             if (index < 0 || index >= list.length) {
-                throw new ArgumentOutOfRangeException(nameof(index));
+                SystemExceptionUtility.ThrowArgumentOutOfRangeException(nameof(index));
             }
 
             if (count < 0) {
-                throw new ArgumentOutOfRangeException(nameof(count), "Non-negative number required.");
+                SystemExceptionUtility.ThrowArgumentOutOfRangeException(nameof(count), "Non-negative number required.");
             }
 
             if (index + count > list.length) {
-                throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
+                SystemExceptionUtility.ThrowArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
             }
 
             Array.Sort(list.data, index, count, comparer ?? Comparer<T>.Default);

--- a/Scellecs.Morpeh/Core/Exceptions/SystemExceptionUtility.cs
+++ b/Scellecs.Morpeh/Core/Exceptions/SystemExceptionUtility.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+namespace Scellecs.Morpeh {
+    public static class SystemExceptionUtility {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentException(string message) {
+            throw new ArgumentException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentException(string parameterName, string message) {
+            throw new ArgumentException(message, parameterName);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentOutOfRangeException(string parameterName) {
+            throw new ArgumentOutOfRangeException(parameterName);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentOutOfRangeException(string parameterName, string message) {
+            throw new ArgumentOutOfRangeException(parameterName, message);
+        }
+    }
+}

--- a/Scellecs.Morpeh/Core/Exceptions/SystemExceptionUtility.cs.meta
+++ b/Scellecs.Morpeh/Core/Exceptions/SystemExceptionUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 540e514656d880847b3559ed92762d99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scellecs.Morpeh/Core/Native/NativeFilterExtensions.cs
+++ b/Scellecs.Morpeh/Core/Native/NativeFilterExtensions.cs
@@ -16,7 +16,7 @@ namespace Scellecs.Morpeh.Native {
                 filter.chunks.Clear();
                 
                 if (filter.chunks.capacity < filter.archetypesLength) {
-                    filter.chunks.Resize(filter.archetypesCapacity);
+                    filter.chunks.Grow(filter.archetypesCapacity);
                 }
             }
             

--- a/Scellecs.Morpeh/Core/Systems/SystemsGroupExtensions.cs
+++ b/Scellecs.Morpeh/Core/Systems/SystemsGroupExtensions.cs
@@ -277,12 +277,12 @@ namespace Scellecs.Morpeh {
         public static void RemoveInitializer<T>(this SystemsGroup systemsGroup, T initializer) where T : class, IInitializer {
             var index = systemsGroup.newInitializers.IndexOf(initializer);
             if (index >= 0) {
-                systemsGroup.newInitializers.RemoveAt(index);
+                systemsGroup.newInitializers.RemoveAtFast(index);
             }
 
             index = systemsGroup.initializers.IndexOf(initializer);
             if (index >= 0) {
-                systemsGroup.initializers.RemoveAt(index);
+                systemsGroup.initializers.RemoveAtFast(index);
             }
         }
 
@@ -338,7 +338,7 @@ namespace Scellecs.Morpeh {
             var index = disabledCollection.IndexOf(system);
             if (index >= 0) {
                 collection.Add(system);
-                disabledCollection.RemoveAt(index);
+                disabledCollection.RemoveAtFast(index);
                 return true;
             }
 
@@ -365,7 +365,7 @@ namespace Scellecs.Morpeh {
             var index = collection.IndexOf(system);
             if (index >= 0) {
                 disabledCollection.Add(system);
-                collection.RemoveAt(index);
+                collection.RemoveAtFast(index);
                 return true;
             }
 
@@ -391,7 +391,7 @@ namespace Scellecs.Morpeh {
 
             var index = collection.IndexOf(system);
             if (index >= 0) {
-                collection.RemoveAt(index);
+                collection.RemoveAtFast(index);
                 systemsGroup.disposables.Add(system);
                 systemsGroup.RemoveInitializer(system);
                 return true;
@@ -399,7 +399,7 @@ namespace Scellecs.Morpeh {
 
             index = disabledCollection.IndexOf(system);
             if (index >= 0) {
-                disabledCollection.RemoveAt(index);
+                disabledCollection.RemoveAtFast(index);
                 systemsGroup.disposables.Add(system);
                 systemsGroup.RemoveInitializer(system);
                 return true;

--- a/Tests~/FastListTests.cs
+++ b/Tests~/FastListTests.cs
@@ -1,0 +1,796 @@
+﻿using Scellecs.Morpeh.Collections;
+using Xunit.Abstractions;
+
+namespace Tests;
+
+[Collection("Sequential")]
+public abstract class FastListTests<T>(ITestOutputHelper output) {
+
+    private readonly ITestOutputHelper output = output;
+
+    protected abstract T CreateValue();
+    
+    protected virtual EqualityComparer<T> GetEqualityComparer() => EqualityComparer<T>.Default;
+
+    [Fact]
+    public void Add_AddsElementCorrectly() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value = CreateValue();
+        var index = list.Add(value);
+
+        Assert.Equal(0, index);
+        Assert.Equal(1, list.length);
+        Assert.Equal(value, list[0]);
+    }
+
+    [Fact]
+    public void ToArray_CreatesCorrectArray() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value1 = CreateValue();
+        var value2 = CreateValue();
+
+        list.Add(value1);
+        list.Add(value2);
+
+        var array = list.ToArray();
+
+        Assert.Equal(2, array.Length);
+        Assert.Equal(new[] { value1, value2 }, array);
+    }
+
+    [Fact]
+    public void ToArray_EmptyListReturnsEmptyArray() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var array = list.ToArray();
+
+        Assert.Same(Array.Empty<T>(), array);
+    }
+
+    [Fact]
+    public void CopyTo_CopiesAllElementsCorrectly() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var values = new[] { CreateValue(), CreateValue(), CreateValue() };
+
+        foreach (var value in values) {
+            list.Add(value);
+        }
+
+        var destination = new T[list.length];
+        list.CopyTo(destination);
+
+        Assert.Equal(values, destination);
+    }
+
+    [Fact]
+    public void AddRange_AddsMultipleElements() {
+        var list1 = new FastList<T> { comparer = GetEqualityComparer() };
+        var list2 = new FastList<T> { comparer = GetEqualityComparer() };
+
+        var value1 = CreateValue();
+        var value2 = CreateValue();
+        var value3 = CreateValue();
+
+        list1.Add(value1);
+        list2.Add(value2);
+        list2.Add(value3);
+
+        list1.AddRange(list2);
+
+        Assert.Equal(3, list1.length);
+        Assert.Equal(new[] { value1, value2, value3 }, list1.ToArray());
+    }
+
+    [Fact]
+    public void AddRange_DoesNotModifyListWithEmptySource() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        list.Add(CreateValue());
+        var originalLength = list.length;
+        var originalCapacity = list.capacity;
+        var originalValue = list[0];
+
+        var emptyList = new FastList<T>();
+        list.AddRange(emptyList);
+
+        Assert.Equal(originalLength, list.length);
+        Assert.Equal(originalCapacity, list.capacity);
+        Assert.Equal(originalValue, list[0]);
+    }
+
+    [Fact]
+    public void IndexOf_FindsCorrectIndex() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value1 = CreateValue();
+        var value2 = CreateValue();
+
+        list.Add(value1);
+        list.Add(value2);
+
+        Assert.Equal(1, list.IndexOf(value2));
+        Assert.Equal(-1, list.IndexOf(CreateValue()));
+    }
+
+    [Fact]
+    public void RemoveAt_ThrowsOnInvalidIndex() {
+        var list = new FastList<int>();
+        list.Add(42);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveAt(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveAt(1));
+    }
+
+    [Fact]
+    public void RemoveAt_RemovesElementAtIndex() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value1 = CreateValue();
+        var value2 = CreateValue();
+        var value3 = CreateValue();
+
+        list.Add(value1);
+        list.Add(value2);
+        list.Add(value3);
+
+        list.RemoveAt(1);
+
+        Assert.Equal(2, list.length);
+        Assert.Equal(new[] { value1, value3 }, list.ToArray());
+    }
+
+    [Fact]
+    public void RemoveAt_RemovesElementFromBeginningOfList() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value1 = CreateValue();
+        var value2 = CreateValue();
+        var value3 = CreateValue();
+
+        list.Add(value1);
+        list.Add(value2);
+        list.Add(value3);
+
+        list.RemoveAt(0);
+
+        Assert.Equal(2, list.length);
+        Assert.Equal(new[] { value2, value3 }, list.ToArray());
+    }
+
+    [Fact]
+    public void RemoveAt_RemovesLastElement() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value1 = CreateValue();
+        var value2 = CreateValue();
+
+        list.Add(value1);
+        list.Add(value2);
+
+        list.RemoveAt(1);
+
+        Assert.Equal(1, list.length);
+        Assert.Equal(new[] { value1 }, list.ToArray());
+    }
+
+    [Fact]
+    public void RemoveAtFast_RemovesElementAtIndex() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value1 = CreateValue();
+        var value2 = CreateValue();
+        var value3 = CreateValue();
+
+        list.Add(value1);
+        list.Add(value2);
+        list.Add(value3);
+
+        list.RemoveAtFast(1);
+
+        Assert.Equal(2, list.length);
+        Assert.Equal(new[] { value1, value3 }, list.ToArray());
+    }
+
+    [Fact]
+    public void Remove_RemovesElement() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value1 = CreateValue();
+        var value2 = CreateValue();
+        var value3 = CreateValue();
+
+        list.Add(value1);
+        list.Add(value2);
+        list.Add(value3);
+
+        var removed = list.Remove(value2);
+
+        Assert.True(removed);
+        Assert.Equal(2, list.length);
+        Assert.Equal(new[] { value1, value3 }, list.ToArray());
+    }
+
+
+    [Fact]
+    public void Remove_RemovesFirstOccurrenceOfElement() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value1 = CreateValue();
+        var value2 = CreateValue();
+
+        list.Add(value1);
+        list.Add(value2);
+        list.Add(value1);
+
+        var removed = list.Remove(value1);
+
+        Assert.True(removed);
+        Assert.Equal(2, list.length);
+        Assert.Equal(new[] { value2, value1 }, list.ToArray());
+    }
+
+    [Fact]
+    public void Remove_ReturnsFalseWhenElementNotFound() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+
+        var removed = list.Remove(CreateValue());
+
+        Assert.False(removed);
+        Assert.Equal(2, list.length);
+    }
+
+    [Fact]
+    public void RemoveSwapBack_RemovesElementAndSwapsWithLast() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value1 = CreateValue();
+        var value2 = CreateValue();
+        var value3 = CreateValue();
+
+        list.Add(value1);
+        list.Add(value2);
+        list.Add(value3);
+
+        var removed = list.RemoveSwapBack(value2);
+
+        Assert.True(removed);
+        Assert.Equal(2, list.length);
+        Assert.Equal(value3, list[1]);
+    }
+
+    [Fact]
+    public void RemoveSwapBack_ReturnsFalseIfElementNotFound() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+
+        var removed = list.RemoveSwapBack(CreateValue());
+
+        Assert.False(removed);
+        Assert.Equal(2, list.length);
+    }
+
+    [Fact]
+    public void RemoveAtSwapBack_ThrowsOnInvalidIndex() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        list.Add(CreateValue());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveAtSwapBack(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveAtSwapBack(1));
+    }
+
+    [Fact]
+    public void RemoveAtSwapBack_SwapsWithLastElement() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value1 = CreateValue();
+        var value2 = CreateValue();
+        var value3 = CreateValue();
+
+        list.Add(value1);
+        list.Add(value2);
+        list.Add(value3);
+
+        list.RemoveAtSwapBack(1);
+
+        Assert.Equal(2, list.length);
+        Assert.Equal(value1, list[0]);
+        Assert.Equal(value3, list[1]);
+    }
+
+    [Fact]
+    public void RemoveRange_ThrowsOnInvalidIndex() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        list.Add(CreateValue());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveRange(-1, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveRange(2, 1));
+    }
+
+    [Fact]
+    public void RemoveRange_ThrowsWhenCountExceedsBounds() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+
+        Assert.Throws<ArgumentException>(() => list.RemoveRange(1, 2));
+    }
+
+    [Fact]
+    public void RemoveRange_ThrowsOnNegativeCount() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        list.Add(CreateValue());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveRange(0, -1));
+    }
+
+    [Fact]
+    public void RemoveRange_RemovesSpecifiedRange() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var values = new[] { CreateValue(), CreateValue(), CreateValue(), CreateValue(), CreateValue() };
+        foreach (var value in values) list.Add(value);
+
+        list.RemoveRange(1, 2);
+
+        Assert.Equal(3, list.length);
+        Assert.Equal(new[] { values[0], values[3], values[4] }, list.ToArray());
+    }
+
+    [Fact]
+    public void RemoveRange_RemovesEntireRangeAtEnd() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var values = new[] { CreateValue(), CreateValue(), CreateValue(), CreateValue(), CreateValue() };
+        foreach (var value in values) list.Add(value);
+
+        list.RemoveRange(3, 2);
+
+        Assert.Equal(3, list.length);
+        Assert.Equal(new[] { values[0], values[1], values[2] }, list.ToArray());
+    }
+
+    [Fact]
+    public void RemoveRange_ZeroCountDoesNotModifyList() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        list.Add(CreateValue());
+        var originalLength = list.length;
+        var originalValue = list[0];
+
+        list.RemoveRange(0, 0);
+
+        Assert.Equal(originalLength, list.length);
+        Assert.Equal(originalValue, list[0]);
+    }
+
+    [Fact]
+    public void SwapFast_SwapsElements() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value1 = CreateValue();
+        var value2 = CreateValue();
+        var value3 = CreateValue();
+
+        list.Add(value1);
+        list.Add(value2);
+        list.Add(value3);
+
+        list.SwapFast(0, 2);
+
+        Assert.Equal(3, list.length);
+        Assert.Equal(value3, list[0]);
+        Assert.Equal(value2, list[1]);
+        Assert.Equal(value1, list[2]);
+    }
+
+    [Fact]
+    public void SwapFast_SameIndexDoesNotModifyList() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value = CreateValue();
+        var value2 = CreateValue();
+        list.Add(value);
+        list.Add(value2);
+
+        list.SwapFast(0, 0);
+        list.SwapFast(1, 1);
+
+        Assert.Equal(value, list[0]);
+        Assert.Equal(value2, list[1]);
+    }
+
+    [Fact]
+    public void Clear_ResetsList() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+
+        list.Clear();
+
+        Assert.Equal(0, list.length);
+    }
+
+    [Fact]
+    public void Clear_EmptyListDoesNothing() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var originalCapacity = list.capacity;
+
+        list.Clear();
+
+        Assert.Equal(0, list.length);
+        Assert.Equal(originalCapacity, list.capacity);
+    }
+
+    [Fact]
+    public void Indexer_SetValueAtValidIndex() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var originalValue = CreateValue();
+        var newValue = CreateValue();
+
+        list.Add(originalValue);
+        Assert.Equal(originalValue, list[0]);
+        list[0] = newValue;
+
+        Assert.Equal(newValue, list[0]);
+        Assert.NotEqual(originalValue, list[0]);
+        Assert.Equal(1, list.length);
+    }
+
+    [Fact]
+    public void Indexer_ThrowsArgumentOutOfRangeException() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => list[0] = CreateValue());
+        Assert.Throws<ArgumentOutOfRangeException>(() => list[-1] = CreateValue());
+    }
+
+    [Fact]
+    public void Indexer_SetMultipleValues() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var values = new[] { CreateValue(), CreateValue(), CreateValue() };
+
+        list.Add(values[0]);
+        list.Add(values[1]);
+        list.Add(values[2]);
+
+        list[1] = CreateValue();
+
+        Assert.Equal(3, list.length);
+        Assert.NotEqual(values[1], list[1]);
+    }
+
+    [Fact]
+    public void Grow_IncreasesCapacity() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+
+        var originalLength = list.length;
+        var originalValues = list.ToArray();
+
+        list.Grow(10);
+
+        Assert.True(list.capacity >= 10);
+        Assert.Equal(originalLength, list.length);
+        Assert.Equal(originalValues, list.ToArray());
+    }
+
+    [Fact]
+    public void Grow_SmallerCapacityDoesNotShrink() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var originalCapacity = list.capacity;
+
+        list.Grow(originalCapacity - 1);
+
+        Assert.Equal(originalCapacity, list.capacity);
+    }
+
+    [Fact]
+    public void Enumerator_IteratesOverAllElements() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var values = new[] { CreateValue(), CreateValue(), CreateValue() };
+        foreach (var value in values) {
+            list.Add(value);
+        }
+
+        int count = 0;
+        var enumerator = list.GetEnumerator();
+        while (enumerator.MoveNext()) {
+            Assert.Equal(values[count], enumerator.Current);
+            count++;
+        }
+
+        Assert.Equal(values.Length, count);
+    }
+
+    [Fact]
+    public void ForEach_IteratesOverAllElements() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var values = new[] { CreateValue(), CreateValue(), CreateValue() };
+
+        foreach (var value in values) {
+            list.Add(value);
+        }
+
+        var iteratedValues = new List<T>();
+        foreach (var value in list) {
+            iteratedValues.Add(value);
+        }
+
+        Assert.Equal(values, iteratedValues);
+    }
+
+    [Fact]
+    public void ForEach_IteratesOverEmptyList() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+
+        var iteratedValues = new List<T>();
+        foreach (var value in list) {
+            iteratedValues.Add(value);
+        }
+
+        Assert.Empty(iteratedValues);
+    }
+
+    [Fact]
+    public void For_IteratesOverAllElements() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var values = new[] { CreateValue(), CreateValue(), CreateValue() };
+
+        foreach (var value in values) {
+            list.Add(value);
+        }
+
+        var iteratedValues = new List<T>();
+        for (int i = 0; i < list.length; i++) {
+            iteratedValues.Add(list[i]);
+        }
+
+        Assert.Equal(values, iteratedValues);
+    }
+
+    [Fact]
+    public void For_IterationWithRemoval() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var values = new List<T>();
+
+        for (int i = 0; i < 50; i++) {
+            values.Add(CreateValue());
+        }
+
+        foreach (var value in values) {
+            list.Add(value);
+        }
+
+        var length = list.length;
+        var writeIndex = 0;
+
+        for (int readIndex = 0; readIndex < length; readIndex++) {
+            var element = list[readIndex];
+            if (readIndex % 3 != 2) {
+                list[writeIndex] = element;
+                values[writeIndex] = element;
+                writeIndex++;
+            }
+        }
+
+        if (writeIndex != length) {
+            list.RemoveRange(writeIndex, length - writeIndex);
+            values.RemoveRange(writeIndex, length - writeIndex);
+        }
+
+        Assert.Equal(values.Count, list.length);
+
+        for (int i = 0; i < list.length; i++) {
+            Assert.Equal(values[i], list[i]);
+        }
+    }
+
+    [Fact]
+    public void For_IterationWithRemovalReverseLoop() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var values = new List<T>();
+
+        for (int i = 0; i < 50; i++) {
+            values.Add(CreateValue());
+        }
+
+        foreach (var value in values) {
+            list.Add(value);
+        }
+
+        for (int i = list.length - 1; i >= 0; i--) {
+            if (i % 3 == 2) {
+                list.RemoveAt(i);
+                values.RemoveAt(i);
+            }
+        }
+
+        Assert.Equal(values.Count, list.length);
+
+        for (int i = 0; i < list.length; i++) {
+            Assert.Equal(values[i], list[i]);
+        }
+    }
+
+    [Fact]
+    public void Sort_EmptyListDoesNotThrow() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        Assert.Empty(list.ToArray());
+        list.Sort();
+        Assert.Empty(list.ToArray());
+    }
+
+    [Fact]
+    public void Sort_SingleElementRemainsUnchanged() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value = CreateValue();
+        list.Add(value);
+
+        list.Sort();
+
+        Assert.Single(list.ToArray());
+        Assert.Equal(value, list[0]);
+    }
+
+    [Theory]
+    [InlineData(-1, 1)]
+    [InlineData(5, 1)]
+    public void Sort_RangeInvalidIndexThrowsArgumentOutOfRangeException(int index, int count) {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.Sort(index, count));
+    }
+
+    [Theory]
+    [InlineData(0, 6)]
+    [InlineData(3, 3)]
+    public void Sort_RangeInvalidCountThrowsArgumentException(int index, int count) {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+
+        Assert.Throws<ArgumentException>(() => list.Sort(index, count));
+    }
+
+    [Fact]
+    public void Sort_RangeNegativeCountThrowsArgumentOutOfRangeException() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+        list.Add(CreateValue());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.Sort(-1, 4));
+    }
+
+    [Fact]
+    public void Sort_RangeZeroCountDoesNotModifyList() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var values = new[] { CreateValue(), CreateValue(), CreateValue() };
+        foreach (var value in values) {
+            list.Add(value);
+        }
+
+        var originalArray = list.ToArray();
+        list.Sort(1, 0);
+
+        Assert.Equal(originalArray, list.ToArray());
+    }
+
+    [Fact]
+    public void SortDefaultComparer_MultipleElementsSortsCorrectly() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var values = new[] { CreateValue(), CreateValue(), CreateValue() };
+        foreach (var value in values) {
+            list.Add(value);
+        }
+
+        if (!values.All(x => x is IComparable)) {
+            Assert.Throws<InvalidOperationException>(() => list.Sort());
+            return;
+        }
+
+        var expectedArray = values.OrderBy(x => x).ToArray();
+        list.Sort();
+
+        Assert.Equal(expectedArray, list.ToArray());
+    }
+
+    [Fact]
+    public void SortDefaultComparer_RangeSortsSpecifiedRangeOnly() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var values = new[] { CreateValue(), CreateValue(), CreateValue(), CreateValue(), CreateValue() };
+        foreach (var value in values) {
+            list.Add(value);
+        }
+
+        if (!values.All(x => x is IComparable)) {
+            Assert.Throws<InvalidOperationException>(() => list.Sort());
+            return;
+        }
+
+        var partialSort = values.ToArray();
+        Array.Sort(partialSort, 1, 3);
+
+        list.Sort(1, 3);
+
+        Assert.Equal(partialSort, list.ToArray());
+    }
+
+    [Fact]
+    public void SortDefaultComparer_PreservesElementsOutsideRange() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var values = new[] { CreateValue(), CreateValue(), CreateValue(), CreateValue(), CreateValue() };
+        foreach (var value in values) {
+            list.Add(value);
+        }
+
+        if (!values.All(x => x is IComparable)) {
+            Assert.Throws<InvalidOperationException>(() => list.Sort());
+            return;
+        }
+
+        var originalFirst = list[0];
+        var originalLast = list[4];
+
+        list.Sort(1, 3);
+
+        Assert.Equal(originalFirst, list[0]);
+        Assert.Equal(originalLast, list[4]);
+    }
+}
+
+public class FastListIntTests(ITestOutputHelper output) : FastListTests<int>(output) {
+    private int value = 0;
+
+    protected override int CreateValue() {
+        return this.value++;
+    }
+}
+
+public class FastListObjectTests(ITestOutputHelper output) : FastListTests<object>(output) {
+    protected override object CreateValue() {
+        return new object();
+    }
+}
+
+public class FastListStringTests(ITestOutputHelper output) : FastListTests<string>(output) {
+    private long value = 0;
+
+    protected override string CreateValue() {
+        return this.value++.ToString();
+    }
+}
+
+public class FastListCustomValueTypeTests(ITestOutputHelper output) : FastListTests<Point2D>(output) {
+    private int nextCoord = 0;
+
+    protected override Point2D CreateValue() {
+        var coord = nextCoord++;
+        return new Point2D(coord, coord * 2);
+    }
+}
+
+public class FastListCustomReferenceTypeTests(ITestOutputHelper output) : FastListTests<Person>(output) {
+    private int nextId = 0;
+
+    protected override Person CreateValue() {
+        var id = nextId++;
+        return new Person($"Person{id}", id);
+    }
+
+    protected override EqualityComparer<Person> GetEqualityComparer() {
+        return EqualityComparer<Person>.Default;
+    }
+}
+
+public class FastListPrimitiveValueTypeTests(ITestOutputHelper output) : FastListTests<SimpleColor>(output) {
+    private int r = 0;
+    private int g = 0;
+    private int b = 0;
+
+    protected override SimpleColor CreateValue() {
+        b = (b < 255) ? b + 1 : 0;
+        g = (b == 0 && g < 255) ? g + 1 : g;
+        r = (b == 0 && g == 0 && r < 255) ? r + 1 : r;
+
+        return new SimpleColor((byte)r, (byte)g, (byte)b);
+    }
+}

--- a/Tests~/FastListTests.cs
+++ b/Tests~/FastListTests.cs
@@ -290,6 +290,24 @@ public abstract class FastListTests<T>(ITestOutputHelper output) {
     }
 
     [Fact]
+    public void RemoveAtSwapBackFast_SwapsWithLastElement() {
+        var list = new FastList<T> { comparer = GetEqualityComparer() };
+        var value1 = CreateValue();
+        var value2 = CreateValue();
+        var value3 = CreateValue();
+
+        list.Add(value1);
+        list.Add(value2);
+        list.Add(value3);
+
+        list.RemoveAtSwapBackFast(1);
+
+        Assert.Equal(2, list.length);
+        Assert.Equal(value1, list[0]);
+        Assert.Equal(value3, list[1]);
+    }
+
+    [Fact]
     public void RemoveRange_ThrowsOnInvalidIndex() {
         var list = new FastList<T> { comparer = GetEqualityComparer() };
         list.Add(CreateValue());

--- a/Tests~/TestTypes.cs
+++ b/Tests~/TestTypes.cs
@@ -1,0 +1,87 @@
+﻿namespace Tests;
+
+public struct Point2D : IEquatable<Point2D>, IComparable<Point2D>, IComparable {
+    public int x;
+    public int y;
+
+    public Point2D(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public bool Equals(Point2D other) => this.x == other.x && this.y == other.y;
+    public override bool Equals(object? obj) => obj is Point2D other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(this.x, this.y);
+
+    public int CompareTo(Point2D other)
+    {
+        var xComparison = this.x.CompareTo(other.x);
+        return xComparison != 0 ? xComparison : this.y.CompareTo(other.y);
+    }
+
+    public int CompareTo(object? obj) {
+        if (obj is null) {
+            return 1;
+        }
+        if (obj is not Point2D other) {
+            throw new ArgumentException("Object must be of type Point2D");
+        }
+
+        return CompareTo(other);
+    }
+
+    public static bool operator ==(Point2D left, Point2D right) => left.Equals(right);
+    public static bool operator !=(Point2D left, Point2D right) => !(left == right);
+    public static bool operator <(Point2D left, Point2D right) => left.CompareTo(right) < 0;
+    public static bool operator >(Point2D left, Point2D right) => left.CompareTo(right) > 0;
+    public static bool operator <=(Point2D left, Point2D right) => left.CompareTo(right) <= 0;
+    public static bool operator >=(Point2D left, Point2D right) => left.CompareTo(right) >= 0;
+}
+
+public sealed class Person : IEquatable<Person>, IComparable<Person>, IComparable {
+    public string Name { get; }
+    public int Age { get; }
+
+    public Person(string name, int age) {
+        this.Name = name;
+        this.Age = age;
+    }
+
+    public bool Equals(Person? other)  {
+        if (other is null) return false;
+        return this.Name == other.Name && this.Age == other.Age;
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as Person);
+
+    public override int GetHashCode() => HashCode.Combine(this.Name, this.Age);
+
+    public int CompareTo(Person? other) {
+        if (other is null) return 1;
+        var nameComparison = string.Compare(this.Name, other.Name, StringComparison.Ordinal);
+        return nameComparison != 0 ? nameComparison : this.Age.CompareTo(other.Age);
+    }
+
+    public int CompareTo(object? obj) {
+        if (obj is null) {
+            return 1;
+        }
+        if (obj is not Person other) {
+            throw new ArgumentException("Object must be of type Person");
+        }
+
+        return CompareTo(other);
+    }
+}
+
+public struct SimpleColor {
+    public byte r;
+    public byte g;
+    public byte b;
+
+    public SimpleColor(byte r, byte g, byte b) {
+        this.r = r;
+        this.g = g;
+        this.b = b;
+    }
+}

--- a/Tests~/Tests.csproj
+++ b/Tests~/Tests.csproj
@@ -10,14 +10,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="xunit" Version="2.5.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Added  
- Custom indexer with bounds checks, while access via ``.data[index]`` remains unchanged.  
- ``RemoveRange`` method: with behavior identical to ``List<T>.RemoveRange``.  
- ``CopyTo(T[] array)`` method.  
- ``RemoveAtFast`` method: removes an element at the specified index without performing bounds checks. All ``RemoveAt`` calls within the core have been replaced with ``RemoveAtFast``.  
- ``Grow`` method: consolidates the functionality of the removed ``Resize`` and ``Expand`` methods.  
- Unit tests for various data types covering all list methods, as well as for different operations in loops.  

### Removed  
- ``Resize`` method, which did not match its name and could not handle downsizing.  
- ``Expand`` method, no longer needed as the ``Grow`` method has been added.  
- ``WithElement`` method.  
- ``RemoveSave`` method.  
- ``RemoveSwapSave`` method.  
- ``RemoveAtSwapSave`` method.  
- ``FastList<T>.ResultSwap`` type.  

### Changed  
- ``AddListRange`` method: renamed to ``AddRange``.
- ``RemoveSwap`` method: its signature and name have been changed to ``bool RemoveSwapBack``. It no longer has ``out`` parameters and includes bounds checks.  
- ``RemoveAtSwap`` method: its signature and name have been changed to ``RemoveAtSwapBack``. It no longer has ``out`` parameters and includes bounds checks.  
- ``ToArray`` method now returns ``Array.Empty<T>`` for an empty list.  

### Fixed  
- ``Remove`` method had broken behavior when an element was not found. It has been changed to ``bool Remove`` and now includes bounds checks.  
- ``RemoveAt`` method had broken behavior with invalid indices. It now includes bounds checks.  
- ``Swap`` method was broken and did not match its name. It has been replaced with `SwapFast`, which swaps list elements without performing bounds checks.  
- ``Sort(index, count)`` method did not include internal bounds checks. It now throws exceptions consistent with ``RemoveRange``, ``RemoveAt``, and ``RemoveAtSwapBack``.  