### PR TITLE
fix: update worldIdentifiers list in RemapWorlds

### DIFF
--- a/Scellecs.Morpeh/Unity/Utils/Editor/WorldBrowser/Models/Hierarchy.cs
+++ b/Scellecs.Morpeh/Unity/Utils/Editor/WorldBrowser/Models/Hierarchy.cs
@@ -91,9 +91,12 @@ namespace Scellecs.Morpeh.Utils.Editor {
 
             this.worldsMap.Clear();
             this.worlds.Clear();
+            this.worldIdentifiers.Clear();
+
             for (int i = 0; i < globalWorldsCount; i++)  {
                 var world = globalWorlds.data[i];
                 this.worldsMap[world.identifier] = world;
+                this.worldIdentifiers.Add(world.identifier);
             }
 
             this.selectedWorlds.RemoveWhere(identifier => !this.worldsMap.ContainsKey(identifier));


### PR DESCRIPTION
## Description
Fixed an issue where World Browser was only showing the Default world because worldIdentifiers list wasn't being updated when new worlds were created.

## Problem
When creating additional worlds (besides Default), they weren't visible in the World Browser dropdown because worldIdentifiers list in Hierarchy class wasn't being updated in RemapWorlds method.

## Solution
Updated RemapWorlds method to clear and repopulate worldIdentifiers list with all existing worlds.

## How to Test
1. Create a new world besides Default
2. Open World Browser window
3. Click "W" button in the top toolbar
4. Verify that all worlds are visible in the dropdown

## Before Fix
Only Default world was visible in World Browser dropdown

## After Fix
All worlds are visible in World Browser dropdown